### PR TITLE
refactor/ffi: move error codes to FFI Error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2343,6 +2343,7 @@ name = "safe-ffi"
 version = "0.5.0"
 dependencies = [
  "ffi_utils 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-api 0.5.0",
  "safe-nd 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe_bindgen 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/safe-api/src/api/errors.rs
+++ b/safe-api/src/api/errors.rs
@@ -35,7 +35,7 @@ pub enum Error {
 
 impl From<Error> for String {
     fn from(error: Error) -> String {
-        error.into()
+        error.to_string()
     }
 }
 
@@ -67,5 +67,17 @@ impl fmt::Display for Error {
         let description = format!("[Error] {} - {}", error_type, error_msg);
 
         write!(f, "{}", description)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_display() {
+        let err = Error::Unknown("test error".to_string());
+        let s: String = err.into();
+        assert_eq!(s, "[Error] Unknown - test error");
     }
 }

--- a/safe-api/src/api/errors.rs
+++ b/safe-api/src/api/errors.rs
@@ -6,7 +6,6 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use self::codes::*;
 use std::fmt;
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -36,92 +35,35 @@ pub enum Error {
 
 impl From<Error> for String {
     fn from(error: Error) -> String {
-        error.description()
+        error.into()
     }
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-
-mod codes {
-    // Auth Errors
-    pub const ERR_AUTH_ERROR: i32 = -100;
-    pub const ERR_CONNECTION_ERROR: i32 = -101;
-    pub const ERR_ACCESS_DENIED_ERROR: i32 = -102;
-
-    // Data Errors
-    pub const ERR_NET_DATA_ERROR: i32 = -200;
-    pub const ERR_CONTENT_NOT_FOUND_ERROR: i32 = -201;
-    pub const ERR_VERSION_NOT_FOUND_ERROR: i32 = -202;
-    pub const ERR_CONTENT_ERROR: i32 = -203;
-    pub const ERR_EMPTY_CONTENT_ERROR: i32 = -204;
-    pub const ERR_ENTRY_NOT_FOUND_ERROR: i32 = -205;
-    pub const ERR_ENTRY_EXISTS_ERROR: i32 = -206;
-    pub const ERR_INVALID_INPUT_ERROR: i32 = -207;
-    pub const ERR_FILE_SYSTEM_ERROR: i32 = -208;
-    pub const ERR_INVALID_MEDIA_TYPE_ERROR: i32 = -209;
-
-    // Balance Errors
-    pub const ERR_INVALID_AMOUNT_ERROR: i32 = -300;
-    pub const ERR_NOT_ENOUGH_BALANCE_ERROR: i32 = -301;
-    pub const ERR_INVALID_XOR_URL_ERROR: i32 = -400;
-
-    // Misc Errors
-    pub const ERR_UNEXPECTED_ERROR: i32 = -500;
-    pub const ERR_UNKNOWN_ERROR: i32 = -501;
-    pub const ERR_STRING_ERROR: i32 = -502;
-}
-
-impl Error {
-    pub fn error_code(&self) -> i32 {
-        match *self {
-            Error::AuthError(ref _error) => ERR_AUTH_ERROR,
-            Error::ConnectionError(ref _error) => ERR_CONNECTION_ERROR,
-            Error::NetDataError(ref _error) => ERR_NET_DATA_ERROR,
-            Error::ContentNotFound(ref _error) => ERR_CONTENT_NOT_FOUND_ERROR,
-            Error::VersionNotFound(ref _error) => ERR_VERSION_NOT_FOUND_ERROR,
-            Error::ContentError(ref _error) => ERR_CONTENT_ERROR,
-            Error::EmptyContent(ref _error) => ERR_EMPTY_CONTENT_ERROR,
-            Error::AccessDenied(ref _error) => ERR_ACCESS_DENIED_ERROR,
-            Error::EntryNotFound(ref _error) => ERR_ENTRY_NOT_FOUND_ERROR,
-            Error::EntryExists(ref _error) => ERR_ENTRY_EXISTS_ERROR,
-            Error::InvalidInput(ref _error) => ERR_INVALID_INPUT_ERROR,
-            Error::InvalidAmount(ref _error) => ERR_INVALID_AMOUNT_ERROR,
-            Error::InvalidXorUrl(ref _error) => ERR_INVALID_XOR_URL_ERROR,
-            Error::NotEnoughBalance(ref _error) => ERR_NOT_ENOUGH_BALANCE_ERROR,
-            Error::FilesSystemError(ref _error) => ERR_FILE_SYSTEM_ERROR,
-            Error::InvalidMediaType(ref _error) => ERR_INVALID_MEDIA_TYPE_ERROR,
-            Error::Unexpected(ref _error) => ERR_UNEXPECTED_ERROR,
-            Error::Unknown(ref _error) => ERR_UNKNOWN_ERROR,
-            Error::StringError(ref _error) => ERR_STRING_ERROR,
-        }
-    }
-
-    pub fn description(&self) -> String {
         let (error_type, error_msg) = match self {
-            Error::AuthError(info) => ("AuthError".to_string(), info.to_string()),
-            Error::ConnectionError(info) => ("ConnectionError".to_string(), info.to_string()),
-            Error::NetDataError(info) => ("NetDataError".to_string(), info.to_string()),
-            Error::ContentNotFound(info) => ("ContentNotFound".to_string(), info.to_string()),
-            Error::VersionNotFound(info) => ("VersionNotFound".to_string(), info.to_string()),
-            Error::ContentError(info) => ("ContentError".to_string(), info.to_string()),
-            Error::EmptyContent(info) => ("EmptyContent".to_string(), info.to_string()),
-            Error::AccessDenied(info) => ("AccessDenied".to_string(), info.to_string()),
-            Error::EntryNotFound(info) => ("EntryNotFound".to_string(), info.to_string()),
-            Error::EntryExists(info) => ("EntryExists".to_string(), info.to_string()),
-            Error::InvalidInput(info) => ("InvalidInput".to_string(), info.to_string()),
-            Error::InvalidAmount(info) => ("InvalidAmount".to_string(), info.to_string()),
-            Error::InvalidXorUrl(info) => ("InvalidXorUrl".to_string(), info.to_string()),
-            Error::InvalidMediaType(info) => ("InvalidMediaType".to_string(), info.to_string()),
-            Error::NotEnoughBalance(info) => ("NotEnoughBalance".to_string(), info.to_string()),
-            Error::FilesSystemError(info) => ("FilesSystemError".to_string(), info.to_string()),
-            Error::Unexpected(info) => ("Unexpected".to_string(), info.to_string()),
-            Error::Unknown(info) => ("Unknown".to_string(), info.to_string()),
-            Error::StringError(info) => ("StringError".to_string(), info.to_string()),
+            Error::AuthError(info) => ("AuthError", info),
+            Error::ConnectionError(info) => ("ConnectionError", info),
+            Error::NetDataError(info) => ("NetDataError", info),
+            Error::ContentNotFound(info) => ("ContentNotFound", info),
+            Error::VersionNotFound(info) => ("VersionNotFound", info),
+            Error::ContentError(info) => ("ContentError", info),
+            Error::EmptyContent(info) => ("EmptyContent", info),
+            Error::AccessDenied(info) => ("AccessDenied", info),
+            Error::EntryNotFound(info) => ("EntryNotFound", info),
+            Error::EntryExists(info) => ("EntryExists", info),
+            Error::InvalidInput(info) => ("InvalidInput", info),
+            Error::InvalidAmount(info) => ("InvalidAmount", info),
+            Error::InvalidXorUrl(info) => ("InvalidXorUrl", info),
+            Error::InvalidMediaType(info) => ("InvalidMediaType", info),
+            Error::NotEnoughBalance(info) => ("NotEnoughBalance", info),
+            Error::FilesSystemError(info) => ("FilesSystemError", info),
+            Error::Unexpected(info) => ("Unexpected", info),
+            Error::Unknown(info) => ("Unknown", info),
+            Error::StringError(info) => ("StringError", info),
         };
-        format!("[Error] {} - {}", error_type, error_msg)
+        let description = format!("[Error] {} - {}", error_type, error_msg);
+
+        write!(f, "{}", description)
     }
 }

--- a/safe-api/src/api/errors.rs
+++ b/safe-api/src/api/errors.rs
@@ -41,26 +41,28 @@ impl From<Error> for String {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Error::*;
+
         let (error_type, error_msg) = match self {
-            Error::AuthError(info) => ("AuthError", info),
-            Error::ConnectionError(info) => ("ConnectionError", info),
-            Error::NetDataError(info) => ("NetDataError", info),
-            Error::ContentNotFound(info) => ("ContentNotFound", info),
-            Error::VersionNotFound(info) => ("VersionNotFound", info),
-            Error::ContentError(info) => ("ContentError", info),
-            Error::EmptyContent(info) => ("EmptyContent", info),
-            Error::AccessDenied(info) => ("AccessDenied", info),
-            Error::EntryNotFound(info) => ("EntryNotFound", info),
-            Error::EntryExists(info) => ("EntryExists", info),
-            Error::InvalidInput(info) => ("InvalidInput", info),
-            Error::InvalidAmount(info) => ("InvalidAmount", info),
-            Error::InvalidXorUrl(info) => ("InvalidXorUrl", info),
-            Error::InvalidMediaType(info) => ("InvalidMediaType", info),
-            Error::NotEnoughBalance(info) => ("NotEnoughBalance", info),
-            Error::FilesSystemError(info) => ("FilesSystemError", info),
-            Error::Unexpected(info) => ("Unexpected", info),
-            Error::Unknown(info) => ("Unknown", info),
-            Error::StringError(info) => ("StringError", info),
+            AuthError(info) => ("AuthError", info),
+            ConnectionError(info) => ("ConnectionError", info),
+            NetDataError(info) => ("NetDataError", info),
+            ContentNotFound(info) => ("ContentNotFound", info),
+            VersionNotFound(info) => ("VersionNotFound", info),
+            ContentError(info) => ("ContentError", info),
+            EmptyContent(info) => ("EmptyContent", info),
+            AccessDenied(info) => ("AccessDenied", info),
+            EntryNotFound(info) => ("EntryNotFound", info),
+            EntryExists(info) => ("EntryExists", info),
+            InvalidInput(info) => ("InvalidInput", info),
+            InvalidAmount(info) => ("InvalidAmount", info),
+            InvalidXorUrl(info) => ("InvalidXorUrl", info),
+            InvalidMediaType(info) => ("InvalidMediaType", info),
+            NotEnoughBalance(info) => ("NotEnoughBalance", info),
+            FilesSystemError(info) => ("FilesSystemError", info),
+            Unexpected(info) => ("Unexpected", info),
+            Unknown(info) => ("Unknown", info),
+            StringError(info) => ("StringError", info),
         };
         let description = format!("[Error] {} - {}", error_type, error_msg);
 

--- a/safe-api/src/api/fake_scl.rs
+++ b/safe-api/src/api/fake_scl.rs
@@ -338,11 +338,7 @@ impl SafeApp for SafeAppFake {
     }
 
     #[allow(dead_code)]
-    fn get_current_seq_append_only_data_version(
-        &self,
-        name: XorName,
-        _tag: u64,
-    ) -> Result<u64> {
+    fn get_current_seq_append_only_data_version(&self, name: XorName, _tag: u64) -> Result<u64> {
         debug!("Getting seq appendable data, length for: {:?}", name);
         let xorname_hex = xorname_to_hex(&name);
         let length = match self.fake_vault.published_seq_append_only.get(&xorname_hex) {

--- a/safe-api/src/api/nrs_map.rs
+++ b/safe-api/src/api/nrs_map.rs
@@ -320,11 +320,7 @@ fn validate_nrs_link(link: &str) -> Result<()> {
     }
 }
 
-fn setup_nrs_tree(
-    nrs_map: &NrsMap,
-    mut sub_names: Vec<String>,
-    link: &str,
-) -> Result<NrsMap> {
+fn setup_nrs_tree(nrs_map: &NrsMap, mut sub_names: Vec<String>, link: &str) -> Result<NrsMap> {
     let mut updated_nrs_map = nrs_map.clone();
     let curr_sub_name = if sub_names.is_empty() {
         let definition_data = create_public_name_description(link)?;
@@ -367,10 +363,7 @@ fn setup_nrs_tree(
     }
 }
 
-fn remove_nrs_sub_tree(
-    nrs_map: &NrsMap,
-    mut sub_names: Vec<String>,
-) -> Result<(NrsMap, String)> {
+fn remove_nrs_sub_tree(nrs_map: &NrsMap, mut sub_names: Vec<String>) -> Result<(NrsMap, String)> {
     let mut updated_nrs_map = nrs_map.clone();
     let curr_sub_name = if sub_names.is_empty() {
         match nrs_map.get_default()? {

--- a/safe-api/src/api/safe_client_libs.rs
+++ b/safe-api/src/api/safe_client_libs.rs
@@ -372,11 +372,7 @@ impl SafeApp for SafeAppScl {
         Ok((data_length, data))
     }
 
-    fn get_current_seq_append_only_data_version(
-        &self,
-        name: XorName,
-        tag: u64,
-    ) -> Result<u64> {
+    fn get_current_seq_append_only_data_version(&self, name: XorName, tag: u64) -> Result<u64> {
         debug!("Getting seq appendable data, length for: {:?}", name);
 
         let safe_app: &App = self.get_safe_app()?;

--- a/safe-api/src/api/safe_net.rs
+++ b/safe-api/src/api/safe_net.rs
@@ -73,11 +73,7 @@ pub trait SafeApp {
         tag: u64,
     ) -> Result<(u64, AppendOnlyDataRawData)>;
 
-    fn get_current_seq_append_only_data_version(
-        &self,
-        name: XorName,
-        tag: u64,
-    ) -> Result<u64>;
+    fn get_current_seq_append_only_data_version(&self, name: XorName, tag: u64) -> Result<u64>;
 
     fn get_seq_append_only_data(
         &self,

--- a/safe-api/src/api/wallet.rs
+++ b/safe-api/src/api/wallet.rs
@@ -201,10 +201,7 @@ impl Safe {
         Ok(total_balance.to_string())
     }
 
-    pub fn wallet_get_default_balance(
-        &self,
-        url: &str,
-    ) -> Result<(WalletSpendableBalance, u64)> {
+    pub fn wallet_get_default_balance(&self, url: &str) -> Result<(WalletSpendableBalance, u64)> {
         let (xorurl_encoder, _) = self.parse_and_resolve_url(url)?;
         let default = self
             .safe_app

--- a/safe-ffi/Cargo.toml
+++ b/safe-ffi/Cargo.toml
@@ -23,12 +23,14 @@ crate_type = ["staticlib", "rlib", "cdylib"]
 path = "lib.rs"
 
 [dependencies]
-safe-api = { path = "../safe-api" }
 ffi_utils = "~0.13.0"
+# Required by ffi_utils macros.
+log = "~0.4.8"
+safe-api = { path = "../safe-api" }
 safe_core = { git = "https://github.com/maidsafe/safe_client_libs", branch = "master"}
+safe-nd = "~0.4.0"
 serde = "1.0.91"
 serde_json = "1.0.39"
-safe-nd = "~0.4.0"
 
 [dev-dependencies]
 unwrap = "~1.2.1"

--- a/safe-ffi/ffi/errors.rs
+++ b/safe-ffi/ffi/errors.rs
@@ -7,65 +7,106 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use ffi_utils::{ErrorCode, StringError};
-use safe_api::Error;
+use safe_api::Error as NativeError;
 use std::ffi::NulError;
 use std::fmt;
+
+mod codes {
+    // Auth Errors
+    pub const ERR_AUTH_ERROR: i32 = -100;
+    pub const ERR_CONNECTION_ERROR: i32 = -101;
+    pub const ERR_ACCESS_DENIED_ERROR: i32 = -102;
+
+    // Data Errors
+    pub const ERR_NET_DATA_ERROR: i32 = -200;
+    pub const ERR_CONTENT_NOT_FOUND_ERROR: i32 = -201;
+    pub const ERR_VERSION_NOT_FOUND_ERROR: i32 = -202;
+    pub const ERR_CONTENT_ERROR: i32 = -203;
+    pub const ERR_EMPTY_CONTENT_ERROR: i32 = -204;
+    pub const ERR_ENTRY_NOT_FOUND_ERROR: i32 = -205;
+    pub const ERR_ENTRY_EXISTS_ERROR: i32 = -206;
+    pub const ERR_INVALID_INPUT_ERROR: i32 = -207;
+    pub const ERR_FILE_SYSTEM_ERROR: i32 = -208;
+    pub const ERR_INVALID_MEDIA_TYPE_ERROR: i32 = -209;
+
+    // Balance Errors
+    pub const ERR_INVALID_AMOUNT_ERROR: i32 = -300;
+    pub const ERR_NOT_ENOUGH_BALANCE_ERROR: i32 = -301;
+    pub const ERR_INVALID_XOR_URL_ERROR: i32 = -400;
+
+    // Misc Errors
+    pub const ERR_UNEXPECTED_ERROR: i32 = -500;
+    pub const ERR_UNKNOWN_ERROR: i32 = -501;
+    pub const ERR_STRING_ERROR: i32 = -502;
+}
 
 pub type Result<T> = std::result::Result<T, FfiError>;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct FfiError(Error);
-
-impl FfiError {
-    pub fn error_code(&self) -> i32 {
-        self.0.error_code()
-    }
-
-    pub fn description(&self) -> String {
-        self.0.description()
-    }
-}
+pub struct FfiError(NativeError);
 
 impl fmt::Display for FfiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0.description())
+        write!(f, "{}", self.0)
     }
 }
 
 impl ErrorCode for FfiError {
     fn error_code(&self) -> i32 {
-        self.error_code()
+        use codes::*;
+
+        match (*self).0 {
+            NativeError::AuthError(ref _error) => ERR_AUTH_ERROR,
+            NativeError::ConnectionError(ref _error) => ERR_CONNECTION_ERROR,
+            NativeError::NetDataError(ref _error) => ERR_NET_DATA_ERROR,
+            NativeError::ContentNotFound(ref _error) => ERR_CONTENT_NOT_FOUND_ERROR,
+            NativeError::VersionNotFound(ref _error) => ERR_VERSION_NOT_FOUND_ERROR,
+            NativeError::ContentError(ref _error) => ERR_CONTENT_ERROR,
+            NativeError::EmptyContent(ref _error) => ERR_EMPTY_CONTENT_ERROR,
+            NativeError::AccessDenied(ref _error) => ERR_ACCESS_DENIED_ERROR,
+            NativeError::EntryNotFound(ref _error) => ERR_ENTRY_NOT_FOUND_ERROR,
+            NativeError::EntryExists(ref _error) => ERR_ENTRY_EXISTS_ERROR,
+            NativeError::InvalidInput(ref _error) => ERR_INVALID_INPUT_ERROR,
+            NativeError::InvalidAmount(ref _error) => ERR_INVALID_AMOUNT_ERROR,
+            NativeError::InvalidXorUrl(ref _error) => ERR_INVALID_XOR_URL_ERROR,
+            NativeError::NotEnoughBalance(ref _error) => ERR_NOT_ENOUGH_BALANCE_ERROR,
+            NativeError::FilesSystemError(ref _error) => ERR_FILE_SYSTEM_ERROR,
+            NativeError::InvalidMediaType(ref _error) => ERR_INVALID_MEDIA_TYPE_ERROR,
+            NativeError::Unexpected(ref _error) => ERR_UNEXPECTED_ERROR,
+            NativeError::Unknown(ref _error) => ERR_UNKNOWN_ERROR,
+            NativeError::StringError(ref _error) => ERR_STRING_ERROR,
+        }
     }
 }
 
-impl From<Error> for FfiError {
-    fn from(error: Error) -> Self {
-        FfiError(error)
+impl From<NativeError> for FfiError {
+    fn from(error: NativeError) -> Self {
+        Self(error)
     }
 }
 
 impl From<StringError> for FfiError {
     fn from(_error: StringError) -> Self {
-        FfiError(Error::StringError("string conversion error".to_string()))
+        NativeError::StringError("string conversion error".to_string()).into()
     }
 }
 
 impl<'a> From<&'a str> for FfiError {
     fn from(s: &'a str) -> Self {
-        FfiError(Error::Unexpected(s.to_string()))
+        NativeError::Unexpected(s.to_string()).into()
     }
 }
 
 impl From<NulError> for FfiError {
     fn from(_error: NulError) -> Self {
-        FfiError(Error::Unexpected("Null error".to_string()))
+        NativeError::Unexpected("Null error".to_string()).into()
     }
 }
 
 impl From<serde_json::error::Error> for FfiError {
     fn from(_error: serde_json::error::Error) -> Self {
-        FfiError(Error::StringError(
+        NativeError::StringError(
             "Failed to serialize or deserialize to json".to_string(),
-        ))
+        ).into()
     }
 }

--- a/safe-ffi/ffi/errors.rs
+++ b/safe-ffi/ffi/errors.rs
@@ -40,73 +40,72 @@ mod codes {
     pub const ERR_STRING_ERROR: i32 = -502;
 }
 
-pub type Result<T> = std::result::Result<T, FfiError>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct FfiError(NativeError);
+pub struct Error(NativeError);
 
-impl fmt::Display for FfiError {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-impl ErrorCode for FfiError {
+impl ErrorCode for Error {
     fn error_code(&self) -> i32 {
         use codes::*;
+        use NativeError::*;
 
         match (*self).0 {
-            NativeError::AuthError(ref _error) => ERR_AUTH_ERROR,
-            NativeError::ConnectionError(ref _error) => ERR_CONNECTION_ERROR,
-            NativeError::NetDataError(ref _error) => ERR_NET_DATA_ERROR,
-            NativeError::ContentNotFound(ref _error) => ERR_CONTENT_NOT_FOUND_ERROR,
-            NativeError::VersionNotFound(ref _error) => ERR_VERSION_NOT_FOUND_ERROR,
-            NativeError::ContentError(ref _error) => ERR_CONTENT_ERROR,
-            NativeError::EmptyContent(ref _error) => ERR_EMPTY_CONTENT_ERROR,
-            NativeError::AccessDenied(ref _error) => ERR_ACCESS_DENIED_ERROR,
-            NativeError::EntryNotFound(ref _error) => ERR_ENTRY_NOT_FOUND_ERROR,
-            NativeError::EntryExists(ref _error) => ERR_ENTRY_EXISTS_ERROR,
-            NativeError::InvalidInput(ref _error) => ERR_INVALID_INPUT_ERROR,
-            NativeError::InvalidAmount(ref _error) => ERR_INVALID_AMOUNT_ERROR,
-            NativeError::InvalidXorUrl(ref _error) => ERR_INVALID_XOR_URL_ERROR,
-            NativeError::NotEnoughBalance(ref _error) => ERR_NOT_ENOUGH_BALANCE_ERROR,
-            NativeError::FilesSystemError(ref _error) => ERR_FILE_SYSTEM_ERROR,
-            NativeError::InvalidMediaType(ref _error) => ERR_INVALID_MEDIA_TYPE_ERROR,
-            NativeError::Unexpected(ref _error) => ERR_UNEXPECTED_ERROR,
-            NativeError::Unknown(ref _error) => ERR_UNKNOWN_ERROR,
-            NativeError::StringError(ref _error) => ERR_STRING_ERROR,
+            AuthError(ref _error) => ERR_AUTH_ERROR,
+            ConnectionError(ref _error) => ERR_CONNECTION_ERROR,
+            NetDataError(ref _error) => ERR_NET_DATA_ERROR,
+            ContentNotFound(ref _error) => ERR_CONTENT_NOT_FOUND_ERROR,
+            VersionNotFound(ref _error) => ERR_VERSION_NOT_FOUND_ERROR,
+            ContentError(ref _error) => ERR_CONTENT_ERROR,
+            EmptyContent(ref _error) => ERR_EMPTY_CONTENT_ERROR,
+            AccessDenied(ref _error) => ERR_ACCESS_DENIED_ERROR,
+            EntryNotFound(ref _error) => ERR_ENTRY_NOT_FOUND_ERROR,
+            EntryExists(ref _error) => ERR_ENTRY_EXISTS_ERROR,
+            InvalidInput(ref _error) => ERR_INVALID_INPUT_ERROR,
+            InvalidAmount(ref _error) => ERR_INVALID_AMOUNT_ERROR,
+            InvalidXorUrl(ref _error) => ERR_INVALID_XOR_URL_ERROR,
+            NotEnoughBalance(ref _error) => ERR_NOT_ENOUGH_BALANCE_ERROR,
+            FilesSystemError(ref _error) => ERR_FILE_SYSTEM_ERROR,
+            InvalidMediaType(ref _error) => ERR_INVALID_MEDIA_TYPE_ERROR,
+            Unexpected(ref _error) => ERR_UNEXPECTED_ERROR,
+            Unknown(ref _error) => ERR_UNKNOWN_ERROR,
+            StringError(ref _error) => ERR_STRING_ERROR,
         }
     }
 }
 
-impl From<NativeError> for FfiError {
+impl From<NativeError> for Error {
     fn from(error: NativeError) -> Self {
         Self(error)
     }
 }
 
-impl From<StringError> for FfiError {
+impl From<StringError> for Error {
     fn from(_error: StringError) -> Self {
-        NativeError::StringError("string conversion error".to_string()).into()
+        NativeError::StringError("string conversion error".into()).into()
     }
 }
 
-impl<'a> From<&'a str> for FfiError {
+impl<'a> From<&'a str> for Error {
     fn from(s: &'a str) -> Self {
-        NativeError::Unexpected(s.to_string()).into()
+        NativeError::Unexpected(s.into()).into()
     }
 }
 
-impl From<NulError> for FfiError {
+impl From<NulError> for Error {
     fn from(_error: NulError) -> Self {
-        NativeError::Unexpected("Null error".to_string()).into()
+        NativeError::Unexpected("Null error".into()).into()
     }
 }
 
-impl From<serde_json::error::Error> for FfiError {
+impl From<serde_json::error::Error> for Error {
     fn from(_error: serde_json::error::Error) -> Self {
-        NativeError::StringError(
-            "Failed to serialize or deserialize to json".to_string(),
-        ).into()
+        NativeError::StringError("Failed to serialize or deserialize to json".into()).into()
     }
 }

--- a/safe-ffi/ffi/fetch.rs
+++ b/safe-ffi/ffi/fetch.rs
@@ -1,4 +1,4 @@
-use super::errors::Result;
+use super::errors::{FfiError, Result};
 use super::ffi_structs::{
     nrs_map_container_info_into_repr_c, wallet_spendable_balances_into_repr_c, FilesContainer,
     NrsMapContainerInfo, PublishedImmutableData, SafeKey, Wallet,
@@ -162,9 +162,10 @@ unsafe fn invoke_callback(
             o_keys(user_data.0, &keys);
         }
         Err(err) => {
+            let (error_code, description) = ffi_error!(FfiError::from(err.clone()));
             let ffi_result = NativeResult {
-                error_code: err.error_code(),
-                description: Some(err.description()),
+                error_code,
+                description: Some(description),
             };
             o_err(user_data.0, &ffi_result.into_repr_c()?);
         }

--- a/safe-ffi/ffi/fetch.rs
+++ b/safe-ffi/ffi/fetch.rs
@@ -1,4 +1,4 @@
-use super::errors::{FfiError, Result};
+use super::errors::{Error, Result};
 use super::ffi_structs::{
     nrs_map_container_info_into_repr_c, wallet_spendable_balances_into_repr_c, FilesContainer,
     NrsMapContainerInfo, PublishedImmutableData, SafeKey, Wallet,
@@ -162,7 +162,7 @@ unsafe fn invoke_callback(
             o_keys(user_data.0, &keys);
         }
         Err(err) => {
-            let (error_code, description) = ffi_error!(FfiError::from(err.clone()));
+            let (error_code, description) = ffi_error!(Error::from(err.clone()));
             let ffi_result = NativeResult {
                 error_code,
                 description: Some(description),

--- a/safe-ffi/lib.rs
+++ b/safe-ffi/lib.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+#[macro_use]
 extern crate ffi_utils;
 
 pub mod ffi;


### PR DESCRIPTION
This PR provides a nicer separation of concerns than previously. Now FFI-specific error codes do not appear outside the `ffi` module. The organization of the code is also simplified with respect to the Native and FFI error types.

Resolves #291 