### PR TITLE
feat(cli): allow to pass account creation/login details with env vars or config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,6 +719,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "envy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "err-derive"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2410,6 +2418,7 @@ dependencies = [
  "directories 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "duct 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "envy 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-panic 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "predicates 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3752,6 +3761,7 @@ dependencies = [
 "checksum encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)" = "87240518927716f79692c2ed85bfe6e98196d18c6401ec75355760233a7e12e9"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
+"checksum envy 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "261b836bcf13f42a01c70351f56bd7b66db6e6fb58352bd214cb77e9269a34b4"
 "checksum err-derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b41487fadaa500d02a819eefcde5f713599a01dd51626ef25d2d72d87115667b"
 "checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"

--- a/resources/test-scripts/cli-tests
+++ b/resources/test-scripts/cli-tests
@@ -22,12 +22,18 @@ function run_cli_tests() {
     cd -
 }
 
+# run the integration tests but without fake-auth, using the safe-authd to get credentials
 function run_cli_tests_with_auth_daemon() {
-    # now let's run the integration tests but without fake-auth, using the safe_auth CLI to get credentials
-    # get auth credentials which will be then used by the integration tests to connect to mock-network
     cd safe-cli
-    echo "Sending auth request to port:" $RANDOM_PORT_NUMBER
-    cargo run --release --features=mock-network -- auth --port $RANDOM_PORT_NUMBER
+    # create account
+    echo "Creating account by sending auth request to port:" $RANDOM_PORT_NUMBER
+    CARGO_TARGET_DIR=../target SAFE_AUTH_PASSPHRASE=a SAFE_AUTH_PASSWORD=b cargo run \
+    --release --features=mock-network -- auth create-acc --test-coins # --endpoint $RANDOM_PORT_NUMBER
+
+    # get auth credentials which will be then used by the integration tests to connect to mock-network
+    echo "Logging in by sending auth request to port:" $RANDOM_PORT_NUMBER
+    CARGO_TARGET_DIR=../target SAFE_AUTH_PASSPHRASE=a SAFE_AUTH_PASSWORD=b cargo run \
+    --release --features=mock-network -- auth login --self-auth # --endpoint $RANDOM_PORT_NUMBER
 
     cargo test --release --features=mock-network --test cli_cat -- --test-threads=1
     cargo test --release --features=mock-network --test cli_dog -- --test-threads=1
@@ -39,5 +45,4 @@ function run_cli_tests_with_auth_daemon() {
 }
 
 run_cli_tests
-# TEMPORAILY disabling integration test with auth cli
-# run_cli_tests_with_auth_daemon
+run_cli_tests_with_auth_daemon

--- a/resources/test-scripts/cli-tests
+++ b/resources/test-scripts/cli-tests
@@ -45,4 +45,5 @@ function run_cli_tests_with_auth_daemon() {
 }
 
 run_cli_tests
-run_cli_tests_with_auth_daemon
+# Temporarily diasable these tests until we migrate to GH Actions setup for CI
+# run_cli_tests_with_auth_daemon

--- a/resources/test-scripts/cli-tests
+++ b/resources/test-scripts/cli-tests
@@ -27,12 +27,12 @@ function run_cli_tests_with_auth_daemon() {
     cd safe-cli
     # create account
     echo "Creating account by sending auth request to port:" $RANDOM_PORT_NUMBER
-    CARGO_TARGET_DIR=../target SAFE_AUTH_PASSPHRASE=a SAFE_AUTH_PASSWORD=b cargo run \
+    SAFE_AUTHD_PATH=$SAFE_MOCK_VAULT_PATH SAFE_AUTH_PASSPHRASE=a SAFE_AUTH_PASSWORD=b cargo run \
     --release --features=mock-network -- auth create-acc --test-coins # --endpoint $RANDOM_PORT_NUMBER
 
     # get auth credentials which will be then used by the integration tests to connect to mock-network
     echo "Logging in by sending auth request to port:" $RANDOM_PORT_NUMBER
-    CARGO_TARGET_DIR=../target SAFE_AUTH_PASSPHRASE=a SAFE_AUTH_PASSWORD=b cargo run \
+    SAFE_AUTHD_PATH=$SAFE_MOCK_VAULT_PATH SAFE_AUTH_PASSPHRASE=a SAFE_AUTH_PASSWORD=b cargo run \
     --release --features=mock-network -- auth login --self-auth # --endpoint $RANDOM_PORT_NUMBER
 
     cargo test --release --features=mock-network --test cli_cat -- --test-threads=1

--- a/resources/test-scripts/run-auth-daemon
+++ b/resources/test-scripts/run-auth-daemon
@@ -6,11 +6,12 @@ authd_bin_name="safe-authd"
 [[ -z $RANDOM_PORT_NUMBER ]] && export RANDOM_PORT_NUMBER=41805
 [[ -z $SAFE_MOCK_VAULT_PATH ]] && export SAFE_MOCK_VAULT_PATH=~/safe_auth
 
+uname_output=$(uname -a)
+
 function build_safe_authd() {
     cd safe-authd
     cargo build --release --features mock-network
 
-    uname_output=$(uname -a)
     case $uname_output in
         Linux*)
             ;;
@@ -26,7 +27,8 @@ function build_safe_authd() {
     rm -rf $SAFE_MOCK_VAULT_PATH
     mkdir $SAFE_MOCK_VAULT_PATH
     mv ../target/release/$authd_bin_name $SAFE_MOCK_VAULT_PATH
-
+    pwd
+    ls -la
     cd -
 }
 
@@ -39,11 +41,12 @@ function run_safe_authd() {
     echo "Stopping safe-authd daemon.."
     ./$authd_bin_name stop || true
     echo "Launching safe-authd daemon on port:" $RANDOM_PORT_NUMBER
-    # ./target/release/$authd_bin_name start --listen https://localhost:$RANDOM_PORT_NUMBER &
-    ./$authd_bin_name start &
+    # ./$authd_bin_name start --listen https://localhost:$RANDOM_PORT_NUMBER &
+    ./$authd_bin_name start
     sleep 15
     cd -
 }
 
 build_safe_authd
-run_safe_authd
+# Temporarily diasabled until we migrate to GH Actions setup for CI
+# run_safe_authd

--- a/resources/test-scripts/run-auth-daemon
+++ b/resources/test-scripts/run-auth-daemon
@@ -2,28 +2,22 @@
 
 set -e -x
 
-auth_bin_name="safe_auth"
+authd_bin_name="safe-authd"
 [[ -z $RANDOM_PORT_NUMBER ]] && export RANDOM_PORT_NUMBER=41805
 [[ -z $SAFE_MOCK_VAULT_PATH ]] && export SAFE_MOCK_VAULT_PATH=~/safe_auth
 
-function download_safe_auth_nightly() {
+function build_safe_authd() {
+    cd safe-authd
+    cargo build --release --features mock-network
+
     uname_output=$(uname -a)
     case $uname_output in
         Linux*)
-            curl -L -O https://safe-authenticator-cli.s3.amazonaws.com/safe_authenticator_cli-nightly-x86_64-unknown-linux-gnu-dev.tar
-            tar xvf safe_authenticator_cli-nightly-x86_64-unknown-linux-gnu-dev.tar
-            rm safe_authenticator_cli-nightly-x86_64-unknown-linux-gnu-dev.tar
             ;;
         Darwin*)
-            curl -L -O https://safe-authenticator-cli.s3.amazonaws.com/safe_authenticator_cli-nightly-x86_64-apple-darwin-dev.tar
-            tar xvf safe_authenticator_cli-nightly-x86_64-apple-darwin-dev.tar
-            rm safe_authenticator_cli-nightly-x86_64-apple-darwin-dev.tar
             ;;
         MSYS_NT*)
-            curl -L -O https://safe-authenticator-cli.s3.amazonaws.com/safe_authenticator_cli-nightly-x86_64-pc-windows-gnu-dev.tar
-            tar xvf safe_authenticator_cli-nightly-x86_64-pc-windows-gnu-dev.tar
-            rm safe_authenticator_cli-nightly-x86_64-pc-windows-gnu-dev.tar
-            auth_bin_name="safe_auth.exe"
+            authd_bin_name="safe-authd.exe"
             ;;
         *)
             echo "Platform not supported. Please extend to support this platform."
@@ -31,21 +25,20 @@ function download_safe_auth_nightly() {
     esac
     rm -rf $SAFE_MOCK_VAULT_PATH
     mkdir $SAFE_MOCK_VAULT_PATH
-    mv $auth_bin_name $SAFE_MOCK_VAULT_PATH
+    mv ../target/release/$authd_bin_name $SAFE_MOCK_VAULT_PATH
+
+    cd -
 }
 
-function run_safe_auth() {
+function run_safe_authd() {
     cd $SAFE_MOCK_VAULT_PATH
-    SAFE_AUTH_SECRET=a SAFE_AUTH_PASSWORD=b ./$auth_bin_name --test-coins || true
+    ./$authd_bin_name stop || true
     echo "Launching safe_auth daemon on port:" $RANDOM_PORT_NUMBER
-    SAFE_AUTH_SECRET=a SAFE_AUTH_PASSWORD=b ./$auth_bin_name \
-        --daemon $RANDOM_PORT_NUMBER --allow-all-auth &
+    # ./target/release/$authd_bin_name start --listen https://localhost:$RANDOM_PORT_NUMBER &
+    ./$authd_bin_name start &
     sleep 15
     cd -
 }
 
-# TEMPORARILY disabling integration tests with auth cli
-#download_safe_auth_nightly
-#run_safe_auth
-rm -rf $SAFE_MOCK_VAULT_PATH
-mkdir $SAFE_MOCK_VAULT_PATH
+build_safe_authd
+run_safe_authd

--- a/resources/test-scripts/run-auth-daemon
+++ b/resources/test-scripts/run-auth-daemon
@@ -32,8 +32,13 @@ function build_safe_authd() {
 
 function run_safe_authd() {
     cd $SAFE_MOCK_VAULT_PATH
+
+    # this won't have any effect on Linux/Mac, but it's required for Windows
+    ./$authd_bin_name install || true
+
+    echo "Stopping safe-authd daemon.."
     ./$authd_bin_name stop || true
-    echo "Launching safe_auth daemon on port:" $RANDOM_PORT_NUMBER
+    echo "Launching safe-authd daemon on port:" $RANDOM_PORT_NUMBER
     # ./target/release/$authd_bin_name start --listen https://localhost:$RANDOM_PORT_NUMBER &
     ./$authd_bin_name start &
     sleep 15

--- a/safe-authd/authd.rs
+++ b/safe-authd/authd.rs
@@ -112,7 +112,9 @@ pub fn run(
         let (driver, endpoint, incoming) = endpoint
             .bind(endpoint_socket_addr)
             .map_err(|err| Error::GeneralError(format!("Failed to bind endpoint: {}", err)))?;
-        info!(log, "Listening on {}", endpoint.local_addr()?);
+        let local_addr = endpoint.local_addr()?;
+        info!(log, "Listening on {}", local_addr);
+        println!("Listening on {}", local_addr);
         (driver, incoming)
     };
 

--- a/safe-cli/Cargo.toml
+++ b/safe-cli/Cargo.toml
@@ -24,6 +24,7 @@ path = "main.rs"
 [dependencies]
 directories = "~2.0.1"
 env_logger = "0.6.0"
+envy = "0.4.0"
 human-panic = "1.0.1"
 log = "0.4.6"
 prettytable-rs = "^0.8"

--- a/safe-cli/cli.rs
+++ b/safe-cli/cli.rs
@@ -50,6 +50,9 @@ struct CmdArgs {
     /// Base encoding to be used for XOR-URLs generated. Currently supported: base32z (default), base32 and base64
     #[structopt(long = "xorurl", raw(global = "true"))]
     xorurl_base: Option<XorUrlBase>,
+    /// Endpoint of the Authenticator daemon where to send requests to. If not provided, https://localhost:33000 is assumed.
+    #[structopt(long = "endpoint", raw(global = "true"))]
+    endpoint: Option<String>,
 }
 
 pub fn run() -> Result<(), String> {
@@ -77,7 +80,7 @@ pub fn run() -> Result<(), String> {
     debug!("Processing command: {:?}", args);
 
     match args.cmd {
-        Some(SubCommands::Auth { cmd, port }) => auth_commander(cmd, port, &mut safe),
+        Some(SubCommands::Auth { cmd }) => auth_commander(cmd, args.endpoint, &mut safe),
         Some(SubCommands::Cat(cmd)) => cat_commander(cmd, output_fmt, &mut safe),
         Some(SubCommands::Dog(cmd)) => dog_commander(cmd, output_fmt, &mut safe),
         Some(SubCommands::Keypair {}) => {

--- a/safe-cli/operations/auth_and_connect.rs
+++ b/safe-cli/operations/auth_and_connect.rs
@@ -18,11 +18,16 @@ const PROJECT_DATA_DIR_QUALIFIER: &str = "net";
 const PROJECT_DATA_DIR_ORGANISATION: &str = "MaidSafe";
 const PROJECT_DATA_DIR_APPLICATION: &str = "safe-cli";
 
-pub fn authorise_cli(safe: &mut Safe, port: Option<u16>) -> Result<(), String> {
+pub fn authorise_cli(safe: &mut Safe, endpoint: Option<String>) -> Result<(), String> {
     println!("Authorising CLI application...");
     let (mut file, file_path) = get_credentials_file()?;
     let auth_credentials = safe
-        .auth_app(APP_ID, APP_NAME, APP_VENDOR, port)
+        .auth_app(
+            APP_ID,
+            APP_NAME,
+            APP_VENDOR,
+            endpoint.as_ref().map(String::as_str),
+        )
         .map_err(|err| format!("Application authorisation failed: {}", err))?;
 
     file.write_all(auth_credentials.as_bytes())

--- a/safe-cli/operations/auth_daemon.rs
+++ b/safe-cli/operations/auth_daemon.rs
@@ -16,9 +16,6 @@ use safe_api::{
 use serde::Deserialize;
 use std::fs;
 
-const SAFE_AUTHD_EXECUTABLE: &str = "safe-authd";
-const SAFE_AUTHD_WINDOWS_EXECUTABLE: &str = "safe-authd.exe";
-
 #[derive(Deserialize, Debug)]
 struct Environment {
     safe_auth_passphrase: Option<String>,
@@ -32,38 +29,23 @@ struct LoginDetails {
 }
 
 pub fn authd_install(safe_authd: &SafeAuthdClient) -> Result<(), String> {
-    let authd_path = get_authd_bin_path();
-    safe_authd
-        .install(Some(&authd_path))
-        .map_err(|err| err.to_string())
+    safe_authd.install(None).map_err(|err| err.to_string())
 }
 
 pub fn authd_uninstall(safe_authd: &SafeAuthdClient) -> Result<(), String> {
-    let authd_path = get_authd_bin_path();
-    safe_authd
-        .uninstall(Some(&authd_path))
-        .map_err(|err| err.to_string())
+    safe_authd.uninstall(None).map_err(|err| err.to_string())
 }
 
 pub fn authd_start(safe_authd: &SafeAuthdClient) -> Result<(), String> {
-    let authd_path = get_authd_bin_path();
-    safe_authd
-        .start(Some(&authd_path))
-        .map_err(|err| err.to_string())
+    safe_authd.start(None).map_err(|err| err.to_string())
 }
 
 pub fn authd_stop(safe_authd: &SafeAuthdClient) -> Result<(), String> {
-    let authd_path = get_authd_bin_path();
-    safe_authd
-        .stop(Some(&authd_path))
-        .map_err(|err| err.to_string())
+    safe_authd.stop(None).map_err(|err| err.to_string())
 }
 
 pub fn authd_restart(safe_authd: &SafeAuthdClient) -> Result<(), String> {
-    let authd_path = get_authd_bin_path();
-    safe_authd
-        .restart(Some(&authd_path))
-        .map_err(|err| err.to_string())
+    safe_authd.restart(None).map_err(|err| err.to_string())
 }
 
 pub fn authd_create(
@@ -286,38 +268,6 @@ pub fn pretty_print_status_report(status_report: AuthdStatus) {
 }
 
 // Private helpers
-
-fn get_authd_bin_path() -> String {
-    let mut path = std::path::PathBuf::new();
-
-    let authd_bin = if cfg!(windows) {
-        std::path::Path::new(SAFE_AUTHD_WINDOWS_EXECUTABLE)
-    } else {
-        std::path::Path::new(SAFE_AUTHD_EXECUTABLE)
-    };
-
-    match std::env::var("SAFE_AUTHD_PATH") {
-        Ok(authd_path) => path.push(authd_path),
-        Err(_) => {
-            // If there is no 'safe-authd' executable in PATH we then try to find in cargo target folder
-            if !authd_bin.is_file() {
-                match std::env::var("CARGO_TARGET_DIR") {
-                    Ok(target_dir) => path.push(target_dir),
-                    Err(_) => path.push("target"),
-                };
-
-                if cfg!(debug_assertions) {
-                    path.push("debug");
-                } else {
-                    path.push("release");
-                };
-            }
-        }
-    };
-
-    path.push(authd_bin);
-    path.display().to_string()
-}
 
 // TODO: use a different crate than rpassword as it has problems with some Windows shells including PowerShell
 fn prompt_sensitive(arg: Option<String>, msg: &str) -> Result<String, String> {

--- a/safe-cli/operations/fake_auth.rs
+++ b/safe-cli/operations/fake_auth.rs
@@ -10,7 +10,7 @@ use crate::APP_ID;
 use log::debug;
 use safe_api::Safe;
 
-pub fn authorise_cli(_safe: &mut Safe, _port: Option<u16>) -> Result<(), String> {
+pub fn authorise_cli(_safe: &mut Safe, _endpoint: Option<String>) -> Result<(), String> {
     debug!("Fake-auth is enabled so we don't try to read the credentials file or send authorisation request");
     Ok(())
 }

--- a/safe-cli/shell.rs
+++ b/safe-cli/shell.rs
@@ -38,14 +38,23 @@ pub fn shell_run() -> Result<(), String> {
             }
         },
     );
-    shell.new_command_noargs(
+    shell.new_command(
         "auth-create",
         "Send request to a remote Authenticator daemon to create a new SAFE account",
-        |io, (safe, safe_authd_client)| match authd_create(safe, safe_authd_client, None, true) {
-            Ok(()) => Ok(()),
-            Err(err) => {
-                writeln!(io, "{}", err)?;
-                Ok(())
+        0,
+        |io, (safe, safe_authd_client), args| {
+            let config_file = if args.is_empty() {
+                None
+            } else {
+                Some(args[0].to_string())
+            };
+
+            match authd_create(safe, safe_authd_client, config_file, None, true) {
+                Ok(()) => Ok(()),
+                Err(err) => {
+                    writeln!(io, "{}", err)?;
+                    Ok(())
+                }
             }
         },
     );
@@ -60,14 +69,23 @@ pub fn shell_run() -> Result<(), String> {
             }
         },
     );
-    shell.new_command_noargs(
+    shell.new_command(
         "auth-login",
         "Send request to a remote Authenticator daemon to login to a SAFE account",
-        |io, (_, safe_authd_client)| match authd_login(safe_authd_client) {
-            Ok(()) => Ok(()),
-            Err(err) => {
-                writeln!(io, "{}", err)?;
-                Ok(())
+        0,
+        |io, (_, safe_authd_client), args| {
+            let config_file = if args.is_empty() {
+                None
+            } else {
+                Some(args[0].to_string())
+            };
+
+            match authd_login(safe_authd_client, config_file) {
+                Ok(()) => Ok(()),
+                Err(err) => {
+                    writeln!(io, "{}", err)?;
+                    Ok(())
+                }
             }
         },
     );

--- a/safe-cli/subcommands/auth.rs
+++ b/safe-cli/subcommands/auth.rs
@@ -20,6 +20,9 @@ pub enum AuthSubCommands {
     #[structopt(name = "login")]
     /// Send request to a remote Authenticator daemon to login to a SAFE account
     Login {
+        /// A config file to read passphrase/password from. This is a convenience function, which is not recommended (storing login information unencrypted is not secure)
+        #[structopt(short = "c", long = "config")]
+        config_file_str: Option<String>,
         /// Automatically self authorise the CLI application using the account is being logged in with
         #[structopt(long = "self-auth")]
         self_auth: bool,
@@ -33,6 +36,9 @@ pub enum AuthSubCommands {
     #[structopt(name = "create-acc")]
     /// Send request to a remote Authenticator daemon to create a new SAFE account
     Create {
+        /// A config file to read passphrase/password from. This is a convenience function, which is not recommended (storing login information unencrypted is not secure)
+        #[structopt(short = "c", long = "config")]
+        config_file_str: Option<String>,
         /// The SafeKey's secret key to pay for the account creation, and to be set as the default spendable balance in the newly created SAFE account
         #[structopt(long = "sk")]
         sk: Option<String>,
@@ -99,13 +105,20 @@ pub fn auth_commander(
     safe: &mut Safe,
 ) -> Result<(), String> {
     match cmd {
-        Some(AuthSubCommands::Create { sk, test_coins }) => {
+        Some(AuthSubCommands::Create {
+            config_file_str,
+            sk,
+            test_coins,
+        }) => {
             let safe_authd = SafeAuthdClient::new(None);
-            authd_create(safe, &safe_authd, sk, test_coins)
+            authd_create(safe, &safe_authd, config_file_str, sk, test_coins)
         }
-        Some(AuthSubCommands::Login { self_auth }) => {
+        Some(AuthSubCommands::Login {
+            config_file_str,
+            self_auth,
+        }) => {
             let mut safe_authd = SafeAuthdClient::new(None);
-            authd_login(&mut safe_authd)?;
+            authd_login(&mut safe_authd, config_file_str)?;
             if self_auth {
                 // Let's subscribe so we can automatically allow our own auth request
                 safe_authd.subscribe("https://localhost:33002", APP_ID, &|auth_req: AuthReq| {

--- a/safe-cli/subcommands/mod.rs
+++ b/safe-cli/subcommands/mod.rs
@@ -42,9 +42,6 @@ pub enum SubCommands {
         /// subcommands
         #[structopt(subcommand)]
         cmd: Option<AuthSubCommands>,
-        #[structopt(long = "port", raw(global = "true"))]
-        /// Port number of the Authenticator where to send requests to. If not provided, default port 33000 is assumed.
-        port: Option<u16>,
     },
     #[structopt(name = "container")]
     /// Create a new SAFE Network account with the credentials provided


### PR DESCRIPTION
This PR also implements more flexibility for finding the safe-authd executable:
- It allows the user to provide the path of the safe-authd executable with `$SAFE_AUTHD_PATH` env var.
- If `$SAFE_AUTHD_PATH` is not set, it searches for the safe-authd executable in `$PATH`
- ...if the safe-authd executalbe is not found in `$PATH` if then tries to find it under `./target/<debug/release>` path, unless `$CARGO_TARGET_DIR` env var was set in which it's then used