### PR TITLE
fix(authd): URL encode passphrase and password when sent to authd

### DIFF
--- a/safe-api/src/api/authd_client_api.rs
+++ b/safe-api/src/api/authd_client_api.rs
@@ -211,11 +211,13 @@ impl SafeAuthdClient {
     }
 
     // Send a login action request to remote authd endpoint
-    pub fn log_in(&mut self, secret: &str, password: &str) -> Result<()> {
+    pub fn log_in(&mut self, passphrase: &str, password: &str) -> Result<()> {
         debug!("Attempting to log in on remote authd...");
+        let passphrase_encoded = urlencoding::encode(passphrase);
+        let password_encoded = urlencoding::encode(password);
         let authd_service_url = format!(
             "{}/{}{}/{}",
-            self.authd_endpoint, SAFE_AUTHD_ENDPOINT_LOGIN, secret, password
+            self.authd_endpoint, SAFE_AUTHD_ENDPOINT_LOGIN, passphrase_encoded, password_encoded
         );
 
         info!(
@@ -249,11 +251,17 @@ impl SafeAuthdClient {
     }
 
     // Sends an account creation request to the SAFE Authenticator
-    pub fn create_acc(&self, sk: &str, secret: &str, password: &str) -> Result<()> {
+    pub fn create_acc(&self, sk: &str, passphrase: &str, password: &str) -> Result<()> {
         debug!("Attempting to create a SAFE account on remote authd...");
+        let passphrase_encoded = urlencoding::encode(passphrase);
+        let password_encoded = urlencoding::encode(password);
         let authd_service_url = format!(
             "{}/{}{}/{}/{}",
-            self.authd_endpoint, SAFE_AUTHD_ENDPOINT_CREATE, secret, password, sk
+            self.authd_endpoint,
+            SAFE_AUTHD_ENDPOINT_CREATE,
+            passphrase_encoded,
+            password_encoded,
+            sk
         );
 
         debug!("Sending account creation request to SAFE Authenticator...");
@@ -506,6 +514,8 @@ impl SafeAuthdClient {
         Ok(())
     }
 }
+
+// Private helpers
 
 fn send_unsubscribe(endpoint_url: &str, endpoint: &str) -> Result<String> {
     let url_encoded = urlencoding::encode(endpoint_url);

--- a/safe-authd/requests/create_acc.rs
+++ b/safe-authd/requests/create_acc.rs
@@ -16,13 +16,15 @@ pub fn process_req(
         Err("Incorrect number of arguments for 'create' action".to_string())
     } else {
         println!("Creating an account in SAFE...");
-        let secret = args[0];
-        let password = args[1];
+        let passphrase = urlencoding::decode(args[0])
+            .map_err(|_| "The passphrase couldn't be decoded from the request".to_string())?;
+        let password = urlencoding::decode(args[1])
+            .map_err(|_| "The password couldn't be decoded from the request".to_string())?;
         let sk = args[2];
 
         lock_safe_authenticator(
             safe_auth_handle,
-            |safe_authenticator| match safe_authenticator.create_acc(sk, secret, password) {
+            |safe_authenticator| match safe_authenticator.create_acc(sk, &passphrase, &password) {
                 Ok(_) => {
                     let msg = "Account created successfully";
                     println!("{}", msg);

--- a/safe-authd/requests/log_in.rs
+++ b/safe-authd/requests/log_in.rs
@@ -16,12 +16,14 @@ pub fn process_req(
         Err("Incorrect number of arguments for 'login' action".to_string())
     } else {
         println!("Logging in to SAFE account...");
-        let secret = args[0];
-        let password = args[1];
+        let passphrase = urlencoding::decode(args[0])
+            .map_err(|_| "The passphrase couldn't be decoded from the request".to_string())?;
+        let password = urlencoding::decode(args[1])
+            .map_err(|_| "The password couldn't be decoded from the request".to_string())?;
 
         lock_safe_authenticator(
             safe_auth_handle,
-            |safe_authenticator| match safe_authenticator.log_in(secret, password) {
+            |safe_authenticator| match safe_authenticator.log_in(&passphrase, &password) {
                 Ok(_) => {
                     let msg = "Logged in successfully!";
                     println!("{}", msg);


### PR DESCRIPTION
This allows to use any character as part of the passphrase and password when logging-in or creating an account with authd client APIs.

Eventually we'll use JSON-RPC for the messages format rather than passing everything in the URL of the request.