### PR TITLE
Implements --dump-shellcompletions

### DIFF
--- a/safe-cli/cli.rs
+++ b/safe-cli/cli.rs
@@ -19,6 +19,7 @@ use crate::subcommands::files::files_commander;
 use crate::subcommands::keys::key_commander;
 use crate::subcommands::networks::networks_commander;
 use crate::subcommands::nrs::nrs_commander;
+use crate::subcommands::setup::setup_commander;
 use crate::subcommands::update::update_commander;
 use crate::subcommands::wallet::wallet_commander;
 use crate::subcommands::{OutputFmt, SubCommands};
@@ -105,6 +106,7 @@ pub fn run_with(cmd_args: &[&str], mut safe: &mut Safe) -> Result<(), String> {
             update_commander().map_err(|err| format!("Error performing update: {}", err))
         }
         Some(SubCommands::Keys(cmd)) => key_commander(cmd, output_fmt, &mut safe),
+        Some(SubCommands::Setup(cmd)) => setup_commander(cmd, output_fmt),
         Some(other) => {
             // We treat these separatelly since we need to connect before
             // handling any of these commands

--- a/safe-cli/subcommands/mod.rs
+++ b/safe-cli/subcommands/mod.rs
@@ -17,6 +17,7 @@ pub mod keys;
 pub mod networks;
 pub mod nrs;
 pub mod safe_id;
+pub mod setup;
 pub mod update;
 pub mod wallet;
 
@@ -83,6 +84,9 @@ pub enum SubCommands {
     #[structopt(name = "files")]
     /// Manage files on the SAFE Network
     Files(files::FilesSubCommands),
+    #[structopt(name = "setup")]
+    /// Perform setup tasks
+    Setup(setup::SetupSubCommands),
     #[structopt(name = "keypair")]
     /// Generate a key pair without creating and/or storing a SafeKey on the network
     Keypair {},

--- a/safe-cli/subcommands/setup.rs
+++ b/safe-cli/subcommands/setup.rs
@@ -1,0 +1,129 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use super::helpers::serialise_output;
+use super::OutputFmt;
+use crate::cli::CmdArgs;
+use std::io::Write;
+use structopt::{clap, StructOpt};
+
+// Defines subcommands of 'setup'
+#[derive(StructOpt, Debug)]
+pub enum SetupSubCommands {
+    /// Dump shell completions.
+    #[structopt(name = "completions")]
+    Completions {
+        /// one of: [bash, fish, zsh, powershell, elvish]  default = all shells
+        shell: Option<clap::Shell>,
+    },
+}
+
+// handles 'setup <cmd>' commands.
+pub fn setup_commander(cmd: SetupSubCommands, output_fmt: OutputFmt) -> Result<(), String> {
+    // Let's keep this clean and place each cmd handler in its own func.
+    match cmd {
+        SetupSubCommands::Completions { shell } => setup_completions(shell, output_fmt),
+    }
+}
+
+// differentiates between 'setup completions' and 'setup completions <shell>'
+fn setup_completions(shell: Option<clap::Shell>, output_fmt: OutputFmt) -> Result<(), String> {
+    match shell {
+        Some(shell_id) => setup_completions_dumpone(shell_id, output_fmt),
+        None => setup_completions_dumpall(output_fmt),
+    }
+}
+
+// handles 'setup completions <shell>' command.  dumps completions for single shell.
+fn setup_completions_dumpone(shell: clap::Shell, output_fmt: OutputFmt) -> Result<(), String> {
+    let buf = gen_completions_for_shell(shell)?;
+
+    if OutputFmt::Pretty == output_fmt {
+        // Pretty format just writes the shell completion to stdout
+        std::io::stdout()
+            .write_all(&buf)
+            .map_err(|err| format!("Failed to print shell completions. {}", err))?;
+        println!();
+    } else {
+        // will be serialized as a string.  no object container.
+        match std::str::from_utf8(&buf) {
+            Ok(v) => println!("{}", serialise_output(v, output_fmt)),
+            Err(e) => println!("Invalid UTF-8 sequence: {}", e),
+        };
+    }
+
+    Ok(())
+}
+
+// handles 'setup completions' command.  dumps completions for all shells.
+fn setup_completions_dumpall(output_fmt: OutputFmt) -> Result<(), String> {
+    // get names of available shells and sort them.
+    let mut shellnames = clap::Shell::variants();
+    shellnames.sort();
+
+    if OutputFmt::Pretty == output_fmt {
+        // Pretty format outputs shell completions with header --- <shellname> --- above each
+        // Only useful for human readability/review.  Installers should use --json
+        for shellname in shellnames.iter() {
+            let shell = shellname.parse::<clap::Shell>()?;
+            let buf = gen_completions_for_shell(shell)?;
+
+            println!("--- {} ---", shellname);
+            std::io::stdout()
+                .write_all(&buf)
+                .map_err(|err| format!("Failed to print shell completions. {}", err))?
+        }
+        println!();
+    } else {
+        // To serialise, we first need to build a json object dynamically. looks like:
+        // { "bash": "completion_buf", "powershell": "completion_buf", ... }
+        let mut map = serde_json::map::Map::new();
+
+        for shellname in shellnames.iter() {
+            let shell = shellname.parse::<clap::Shell>()?;
+            let buf = gen_completions_for_shell(shell)?;
+            match std::str::from_utf8(&buf) {
+                Ok(v) => {
+                    map.insert(shellname.to_string(), serde_json::json!(v));
+                }
+                Err(e) => println!("Invalid UTF-8 sequence: {}", e),
+            };
+        }
+
+        let jsonv = serde_json::json!(map);
+
+        println!("{}", serialise_output(&jsonv, output_fmt));
+    }
+
+    Ok(())
+}
+
+// generates completions for a given shell, eg bash.
+fn gen_completions_for_shell(shell: clap::Shell) -> Result<Vec<u8>, String> {
+    // Get exe path
+    let exe_path =
+        std::env::current_exe().map_err(|err| format!("Can't get the exec path: {}", err))?;
+
+    // get filename without preceding path as std::ffi::OsStr (C string)
+    let exec_name_ffi = match exe_path.file_name() {
+        Some(v) => v,
+        None => return Err("Can't extract file_name of executable".to_string()),
+    };
+
+    // Convert OsStr to string.  Can fail if OsStr contains any invalid unicode.
+    let exec_name = match exec_name_ffi.to_str() {
+        Some(v) => v.to_string(),
+        None => return Err("Can't decode unicode in executable name".to_string()),
+    };
+
+    // Generates shell completions for <shell> and prints to stdout
+    let mut buf: Vec<u8> = vec![];
+    CmdArgs::clap().gen_completions_to(exec_name, shell, &mut buf);
+
+    Ok(buf)
+}


### PR DESCRIPTION
Addresses #73 for auto-completion of commands in a shell.

Supports shells:
  bash, fish, zsh, powershell, elvish

The completions are automatically generated from the values in
structopt, so they stay current as the cli params change over time.

To use the completions, eg in bash:

    safe --dump-completions=bash > /tmp/out && source /tmp/out

**Considerations**

1. --dump-completions works for me, but could be renamed to anything, eg --completions is shorter.

2. I didn't use a shortopt (yet).   Can add if wanted.

3. All the logic is contained in a single if statement.. I could move it into a function if desired.

4. Nothing is specific to safe-cli app.  If there is a common code shared between the apps under safe-api, then I could make/move a func into the common area to be called by each of them, so each would have --dump-completions.  Each would need a modification to structopt, and a single fn call.

5. Does *not* presently support completion of dynamic text such as a URL that user may be entering.  See discussion in #73.

6. To be most useful, cargo install (or whatever installer) should have a step to dump completions and install for user.   Exactly how best to do that with would need a bit of research, especially when dealing with various shells and OSes.  For now, this PR lays necessary groundwork.

<!--
#### Thank you for contributing!

Please reference the issue(s) which this pull request addresses using [keywords](https://help.github.com/articles/closing-issues-using-keywords/) such as:

```
Resolves #452
Fixes #363
Closes #408
```

---

Provide QA team and reviewer steps to test the resolution.
For example:

```
QA:
Easiest way to test this PR would be to:
- Start authd
- login
- safe wallet insert <problem link>
- Expect to see an authentication error output

```

---

Commit messages should conform to the format:

```
<type>(<scope>): <description>

[optional body]

```

For example:

```
fix(auth): proper values returned on auth_decode_ipc_msg errors

  - Test case for authenticator error -208 IncompatibleMockStatus
  - Test case for authenticator error -103 when decoding share MData
    request for non-existent MData

```

Commit `type` can be one of:
**feat**: New feature
**fix**: Bug fix
**docs**: Documentation only changes
**style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
**refactor**: A code change that neither fixes a bug nor adds a feature
**perf**: A code change that improves performance
**test**: Adding missing tests
**chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation
**revert**: Reverting a feature, fix, or commit which introduces a regression or new bug

Commit `scope` is open to any succinct term which indicates the effected feature or component.

See [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)

---
Write your description below this line: -->
