### PR TITLE
chore(ci): github actions for release process

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,3 +1,5 @@
+name: Master
+
 on:
   push:
     branches:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,366 @@
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-component:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        component: [safe-cli, safe-ffi]
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: windows-latest
+            target: x86_64-pc-windows-gnu
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --manifest-path=${{ matrix.component }}/Cargo.toml
+      - uses: actions/upload-artifact@master
+        with:
+          name: ${{ matrix.component }}-${{ matrix.target }}-prod
+          path: target/release
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: >
+            --release --manifest-path=${{ matrix.component }}/Cargo.toml
+            --features=fake-auth,mock-network
+      - shell: bash
+        run: |
+          mkdir artifacts
+          find "target/release" -maxdepth 1 -type f -exec cp '{}' artifacts \;
+      - uses: actions/upload-artifact@master
+        with:
+          name: ${{ matrix.component }}-${{ matrix.target }}-dev
+          path: artifacts
+
+  build-ffi-android:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [armv7-linux-androideabi, x86_64-linux-android]
+        type: [dev, prod]
+    env:
+      SAFE_CLI_BUILD_COMPONENT: safe-ffi
+      SAFE_CLI_BUILD_TYPE: ${{ matrix.type }}
+      SAFE_CLI_BUILD_TARGET: ${{ matrix.target }}
+    steps:
+      - uses: actions/checkout@v1
+      - shell: bash
+        run: make build-component
+      - uses: actions/upload-artifact@master
+        with:
+          name: safe-ffi-${{ matrix.target }}-${{ matrix.type }}
+          path: artifacts
+
+  #build-ffi-ios:
+    #runs-on: macOS-latest
+    #strategy:
+      #matrix:
+        #target: [aarch64-apple-ios, x86_64-apple-ios]
+    #env:
+      ##RUST_SODIUM_LIB_DIR: /Users/runner/libsodium
+      #DEVELOPER_DIR: /Applications/Xcode_11.2.app/Contents/Developer
+    #steps:
+      #- shell: bash
+        #run: |
+          #brew install curl
+          #curl -O https://libsodium.s3.amazonaws.com/libsodium-1.0.17-stable-macos.tar.gz
+          #mkdir $HOME/libsodium
+          #mv libsodium-1.0.17-stable-macos.tar.gz $HOME/libsodium
+          #cd $HOME/libsodium
+          #tar xvf libsodium-1.0.17-stable-macos.tar.gz
+          #rm libsodium-1.0.17-stable-macos.tar.gz
+      #- uses: actions/checkout@v1
+      #- uses: actions-rs/toolchain@v1
+        #with:
+          #toolchain: stable
+          #override: true
+          #target: ${{ matrix.target }}
+      #- uses: actions-rs/cargo@v1
+        #with:
+          #command: build
+          #args: --release --manifest-path=safe-ffi/Cargo.toml --target=${{ matrix.target }}
+      #- uses: actions/upload-artifact@master
+        #with:
+          #name: safe-ffi-${{ matrix.target }}-prod
+          #path: target/${{ matrix.target }}/release
+      #- uses: actions-rs/cargo@v1
+        #with:
+          #command: build
+          #args: --release --manifest-path=safe-ffi/Cargo.toml --target=${{ matrix.target }} --features=mock-network
+      #- shell: bash
+        #run: |
+          #mkdir artifacts
+          #find "target/${{ matrix.target }}/release" -maxdepth 1 -type f -exec cp '{}' artifacts \;
+      #- uses: actions/upload-artifact@master
+        #with:
+          #name: safe-ffi-${{ matrix.target }}-dev
+          #path: target/${{ matrix.target }}/release
+
+  #build-ffi-ios-universal:
+    #runs-on: macOS-latest
+    #needs: build-ffi-ios
+    #steps:
+      #- uses: actions/checkout@v1
+      #- uses: actions/download-artifact@master
+        #with:
+          #name: safe-ffi-x86_64-apple-ios-dev
+          #path: artifacts/safe-ffi/dev/x86_64-apple-ios/release
+      #- uses: actions/download-artifact@master
+        #with:
+          #name: safe-ffi-x86_64-apple-ios-prod
+          #path: artifacts/safe-ffi/prod/x86_64-apple-ios/release
+      #- uses: actions/download-artifact@master
+        #with:
+          #name: safe-ffi-aarch64-apple-ios-dev
+          #path: artifacts/safe-ffi/dev/aarch64-apple-ios/release
+      #- uses: actions/download-artifact@master
+        #with:
+          #name: safe-ffi-aarch64-apple-ios-prod
+          #path: artifacts/safe-ffi/prod/aarch64-apple-ios/release
+      #- shell: bash
+        #run: make universal-ios-lib
+      #- uses: actions/upload-artifact@master
+        #with:
+          #name: safe-ffi-apple-ios-dev
+          #path: artifacts/safe-ffi/dev/universal
+      #- uses: actions/upload-artifact@master
+        #with:
+          #name: safe-ffi-apple-ios-prod
+          #path: artifacts/safe-ffi/prod/universal
+
+  # Unfortunately, for artifact retrieval, there's not really a way to avoid having this huge list of
+  # 'download-artifact' actions. We could perhaps implement our own 'retrieve all build artifacts'
+  # action.
+  deploy:
+    runs-on: ubuntu-latest
+    # Put the iOS build in this list when it's working.
+    needs: [build-component, build-ffi-android]
+    env:
+      AWS_ACCESS_KEY_ID: AKIAVVODCRMSDTFZ72NK
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.DEPLOY_USER_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: eu-west-2
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      # Checkout and get all the artifacts built in the previous jobs.
+      - uses: actions/checkout@v1
+      - uses: actions/download-artifact@master
+        with:
+          name: safe-cli-x86_64-pc-windows-gnu-prod
+          path: artifacts/safe-cli/prod/x86_64-pc-windows-gnu/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe-cli-x86_64-pc-windows-gnu-dev
+          path: artifacts/safe-cli/dev/x86_64-pc-windows-gnu/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe-cli-x86_64-unknown-linux-gnu-prod
+          path: artifacts/safe-cli/prod/x86_64-unknown-linux-gnu/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe-cli-x86_64-unknown-linux-gnu-dev
+          path: artifacts/safe-cli/dev/x86_64-unknown-linux-gnu/release
+      #- uses: actions/download-artifact@master
+        #with:
+          #name: safe-cli-x86_64-apple-darwin-prod
+          #path: artifacts/safe-cli/prod/x86_64-apple-darwin/release
+      #- uses: actions/download-artifact@master
+        #with:
+          #name: safe-cli-x86_64-apple-darwin-dev
+          #path: artifacts/safe-cli/dev/x86_64-apple-darwin/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe-ffi-x86_64-pc-windows-gnu-prod
+          path: artifacts/safe-ffi/prod/x86_64-pc-windows-gnu/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe-ffi-x86_64-pc-windows-gnu-dev
+          path: artifacts/safe-ffi/dev/x86_64-pc-windows-gnu/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe-ffi-x86_64-unknown-linux-gnu-prod
+          path: artifacts/safe-ffi/prod/x86_64-unknown-linux-gnu/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe-ffi-x86_64-unknown-linux-gnu-dev
+          path: artifacts/safe-ffi/dev/x86_64-unknown-linux-gnu/release
+      #- uses: actions/download-artifact@master
+        #with:
+          #name: safe-ffi-x86_64-apple-darwin-prod
+          #path: artifacts/safe-ffi/prod/x86_64-apple-darwin/release
+      #- uses: actions/download-artifact@master
+        #with:
+          #name: safe-ffi-x86_64-apple-darwin-dev
+          #path: artifacts/safe-ffi/dev/x86_64-apple-darwin/release
+      #- uses: actions/download-artifact@master
+        #with:
+          #name: safe-ffi-x86_64-apple-darwin-dev
+          #path: artifacts/safe-ffi/dev/x86_64-apple-darwin/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe-ffi-armv7-linux-androideabi-prod
+          path: artifacts/safe-ffi/prod/armv7-linux-androideabi/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe-ffi-armv7-linux-androideabi-dev
+          path: artifacts/safe-ffi/dev/armv7-linux-androideabi/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe-ffi-x86_64-linux-android-prod
+          path: artifacts/safe-ffi/prod/x86_64-linux-android/release
+      - uses: actions/download-artifact@master
+        with:
+          name: safe-ffi-x86_64-linux-android-dev
+          path: artifacts/safe-ffi/dev/x86_64-linux-android/release
+      #- uses: actions/download-artifact@master
+        #with:
+          #name: safe-ffi-apple-ios-prod
+          #path: artifacts/safe-ffi/prod/apple-ios/release
+      #- uses: actions/download-artifact@master
+        #with:
+          #name: safe-ffi-apple-ios-dev
+          #path: artifacts/safe-ffi/dev/apple-ios/release
+
+      # Get information for the release.
+      - shell: bash
+        id: commit_message
+        run: |
+          commit_message=$(git log --format=%B -n 1 ${{ github.sha }})
+          echo "::set-output name=commit_message::$commit_message"
+      - shell: bash
+        id: versioning
+        run: |
+          api_version=$(grep "^version" < safe-api/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+          cli_version=$(grep "^version" < safe-cli/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+          ffi_version=$(grep "^version" < safe-ffi/Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
+          commit_message=$(git log --format=%B -n 1 ${{ github.sha }})
+          echo "::set-output name=api_version::$api_version"
+          echo "::set-output name=cli_version::$cli_version"
+          echo "::set-output name=ffi_version::$ffi_version"
+
+      # Put the artifacts into tar/zip archives for deployment with the release.
+      - shell: bash
+        run: make package-commit_hash-artifacts-for-deploy
+        if: "!startsWith(steps.commit_message.outputs.commit_message, 'Version change')"
+      - shell: bash
+        run: make package-version-artifacts-for-deploy
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      - shell: bash
+        id: release_description
+        run: |
+          description=$(./resources/get_release_description.sh ${{ steps.versioning.outputs.cli_version }})
+          description="${description//'%'/'%25'}"
+          description="${description//$'\n'/'%0A'}"
+          description="${description//$'\r'/'%0D'}"
+          echo "::set-output name=description::$description"
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+
+      # Create the release and attach safe-cli archives as assets.
+      - uses: csexton/create-release@add-body
+        id: create_release
+        with:
+          tag_name: ${{ steps.versioning.outputs.cli_version }}
+          release_name: safe-cli
+          draft: false
+          prerelease: false
+          body: ${{ steps.release_description.outputs.description }}
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/safe-cli-${{ steps.versioning.outputs.cli_version }}-x86_64-unknown-linux-gnu.zip
+          asset_name: safe-cli-${{ steps.versioning.outputs.cli_version }}-x86_64-unknown-linux-gnu.zip
+          asset_content_type: application/zip
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/safe-cli-${{ steps.versioning.outputs.cli_version }}-x86_64-pc-windows-gnu.zip
+          asset_name: safe-cli-${{ steps.versioning.outputs.cli_version }}-x86_64-pc-windows-gnu.zip
+          asset_content_type: application/zip
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      #- uses: actions/upload-release-asset@v1.0.1
+        #with:
+          #upload_url: ${{ steps.create_release.outputs.upload_url }}
+          #asset_path: deploy/prod/safe-cli-${{ steps.versioning.outputs.cli_version }}-x86_64-apple-darwin.zip
+          #asset_name: safe-cli-${{ steps.versioning.outputs.cli_version }}-x86_64-apple-darwin.zip
+          #asset_content_type: application/zip
+        #if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/safe-cli-${{ steps.versioning.outputs.cli_version }}-x86_64-unknown-linux-gnu.tar.gz
+          asset_name: safe-cli-${{ steps.versioning.outputs.cli_version }}-x86_64-unknown-linux-gnu.tar.gz
+          asset_content_type: application/zip
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: deploy/prod/safe-cli-${{ steps.versioning.outputs.cli_version }}-x86_64-pc-windows-gnu.tar.gz
+          asset_name: safe-cli-${{ steps.versioning.outputs.cli_version }}-x86_64-pc-windows-gnu.tar.gz
+          asset_content_type: application/zip
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      #- uses: actions/upload-release-asset@v1.0.1
+        #with:
+          #upload_url: ${{ steps.create_release.outputs.upload_url }}
+          #asset_path: deploy/prod/safe-cli-${{ steps.versioning.outputs.cli_version }}-x86_64-apple-darwin.tar.gz
+          #asset_name: safe-cli-${{ steps.versioning.outputs.cli_version }}-x86_64-apple-darwin.tar.gz
+          #asset_content_type: application/zip
+        #if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      - uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: resources/safe_completion.sh
+          asset_name: safe_completion.sh
+          asset_content_type: application/zip
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+
+      # Upload all the release archives to S3; FFI links will be in the release description.
+      - uses: actions/aws/cli@master
+        with:
+          args: s3 sync deploy/dev s3://safe-cli --acl public-read
+      - uses: actions/aws/cli@master
+        with:
+          args: s3 sync deploy/prod s3://safe-cli --acl public-read
+
+  publish:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - shell: bash
+        id: commit_message
+        run: |
+          commit_message=$(git log --format=%B -n 1 ${{ github.sha }})
+          echo "::set-output name=commit_message::$commit_message"
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      - uses: actions-rs/cargo@v1
+        with:
+          command: login
+          args: ${{ secrets.CRATES_IO_TOKEN }}
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      - uses: actions-rs/cargo@v1
+        with:
+          command: package
+          args: --manifest-path=safe-api/Cargo.toml
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+      - uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --manifest-path=safe-api/Cargo.toml --dry-run
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,147 @@
+on: [pull_request]
+
+jobs:
+  build-ffi-android:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [armv7-linux-androideabi, x86_64-linux-android]
+        type: [dev, prod]
+    env:
+      SAFE_CLI_BUILD_COMPONENT: safe-ffi
+      SAFE_CLI_BUILD_TYPE: ${{ matrix.type }}
+      SAFE_CLI_BUILD_TARGET: ${{ matrix.target }}
+    steps:
+      - uses: actions/checkout@v1
+      - shell: bash
+        run: make build-component
+      - uses: actions/upload-artifact@master
+        with:
+          name: safe-ffi-${{ matrix.target }}-${{ matrix.type }}
+          path: artifacts
+
+  #build-ffi-ios:
+    #runs-on: macOS-latest
+    #strategy:
+      #matrix:
+        #target: [aarch64-apple-ios, x86_64-apple-ios]
+    #env:
+      ##RUST_SODIUM_LIB_DIR: /Users/runner/libsodium
+      #DEVELOPER_DIR: /Applications/Xcode_11.2.app/Contents/Developer
+    #steps:
+      # Remove when rust_sodium is dealt with.
+      #- shell: bash
+        #run: |
+          #brew install curl
+          #curl -O https://libsodium.s3.amazonaws.com/libsodium-1.0.17-stable-macos.tar.gz
+          #mkdir $HOME/libsodium
+          #mv libsodium-1.0.17-stable-macos.tar.gz $HOME/libsodium
+          #cd $HOME/libsodium
+          #tar xvf libsodium-1.0.17-stable-macos.tar.gz
+          #rm libsodium-1.0.17-stable-macos.tar.gz
+      #- uses: actions/checkout@v1
+      #- uses: actions-rs/toolchain@v1
+        #with:
+          #toolchain: stable
+          #override: true
+          #target: ${{ matrix.target }}
+      #- uses: actions-rs/cargo@v1
+        #with:
+          #command: build
+          #args: --release --manifest-path=safe-ffi/Cargo.toml --target=${{ matrix.target }}
+      #- uses: actions/upload-artifact@master
+        #with:
+          #name: safe-ffi-${{ matrix.target }}-prod
+          #path: target/${{ matrix.target }}/release
+      #- uses: actions-rs/cargo@v1
+        #with:
+          #command: build
+          #args: --release --manifest-path=safe-ffi/Cargo.toml --target=${{ matrix.target }} --features=mock-network
+      #- shell: bash
+        #run: |
+          #mkdir artifacts
+          #find "target/${{ matrix.target }}/release" -maxdepth 1 -type f -exec cp '{}' artifacts \;
+      #- uses: actions/upload-artifact@master
+        #with:
+          #name: safe-ffi-${{ matrix.target }}-dev
+          #path: target/${{ matrix.target }}/release
+
+  #build-ffi-ios-universal:
+    #runs-on: macOS-latest
+    #needs: build-ffi-ios
+    #steps:
+      #- uses: actions/checkout@v1
+      #- uses: actions/download-artifact@master
+        #with:
+          #name: safe-ffi-x86_64-apple-ios-dev
+          #path: artifacts/safe-ffi/dev/x86_64-apple-ios/release
+      #- uses: actions/download-artifact@master
+        #with:
+          #name: safe-ffi-x86_64-apple-ios-prod
+          #path: artifacts/safe-ffi/prod/x86_64-apple-ios/release
+      #- uses: actions/download-artifact@master
+        #with:
+          #name: safe-ffi-aarch64-apple-ios-dev
+          #path: artifacts/safe-ffi/dev/aarch64-apple-ios/release
+      #- uses: actions/download-artifact@master
+        #with:
+          #name: safe-ffi-aarch64-apple-ios-prod
+          #path: artifacts/safe-ffi/prod/aarch64-apple-ios/release
+      #- shell: bash
+        #run: make universal-ios-lib
+      #- uses: actions/upload-artifact@master
+        #with:
+          #name: safe-ffi-apple-ios-dev
+          #path: artifacts/safe-ffi/dev/universal
+      #- uses: actions/upload-artifact@master
+        #with:
+          #name: safe-ffi-apple-ios-prod
+          #path: artifacts/safe-ffi/prod/universal
+
+  #build-ffi-ios-universal:
+    #runs-on: macOS-latest
+    #needs: build-ffi-ios
+    #steps:
+      #- uses: actions/checkout@v1
+      #- uses: actions/download-artifact@master
+        #with:
+          #name: safe-ffi-x86_64-apple-ios-dev
+          #path: artifacts/safe-ffi/dev/x86_64-apple-ios/release
+      #- uses: actions/download-artifact@master
+        #with:
+          #name: safe-ffi-x86_64-apple-ios-prod
+          #path: artifacts/safe-ffi/prod/x86_64-apple-ios/release
+      #- uses: actions/download-artifact@master
+        #with:
+          #name: safe-ffi-aarch64-apple-ios-dev
+          #path: artifacts/safe-ffi/dev/aarch64-apple-ios/release
+      #- uses: actions/download-artifact@master
+        #with:
+          #name: safe-ffi-aarch64-apple-ios-prod
+          #path: artifacts/safe-ffi/prod/aarch64-apple-ios/release
+      #- shell: bash
+        #run: make universal-ios-lib
+      #- uses: actions/upload-artifact@master
+        #with:
+          #name: safe-ffi-apple-ios-dev
+          #path: artifacts/safe-ffi/dev/universal
+      #- uses: actions/upload-artifact@master
+        #with:
+          #name: safe-ffi-apple-ios-prod
+          #path: artifacts/safe-ffi/prod/universal
+
+  # Add macOS-latest to the matrix when rust_sodium has been removed.
+  test-component:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        component: [api-tests, cli-tests]
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - shell: bash
+        run: ./resources/test-scripts/${{ matrix.component }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,32 @@
+name: PR
+
 on: [pull_request]
 
+env:
+  RUST_BACKTRACE: 1
+  RUSTFLAGS: "-D warnings"
+
 jobs:
+  clippy:
+    name: Rustfmt-Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-targets --all-features
+
   build-ffi-android:
     runs-on: ubuntu-latest
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ dependencies = [
 [[package]]
 name = "safe_app"
 version = "0.10.0"
-source = "git+https://github.com/maidsafe/safe_client_libs#70448a1d4e725266f4f6159eed963c36635dcc51"
+source = "git+https://github.com/maidsafe/safe_client_libs#6dee0c36af8f97483f6e4e04d8465257a1053f66"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2402,7 +2402,7 @@ dependencies = [
 [[package]]
 name = "safe_authenticator"
 version = "0.10.0"
-source = "git+https://github.com/maidsafe/safe_client_libs#70448a1d4e725266f4f6159eed963c36635dcc51"
+source = "git+https://github.com/maidsafe/safe_client_libs#6dee0c36af8f97483f6e4e04d8465257a1053f66"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2444,7 +2444,7 @@ dependencies = [
 [[package]]
 name = "safe_core"
 version = "0.35.0"
-source = "git+https://github.com/maidsafe/safe_client_libs#70448a1d4e725266f4f6159eed963c36635dcc51"
+source = "git+https://github.com/maidsafe/safe_client_libs#6dee0c36af8f97483f6e4e04d8465257a1053f66"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/resources/build-component.sh
+++ b/resources/build-component.sh
@@ -55,9 +55,7 @@ function build_on_linux() {
     local container_tag
     local uuid
     uuid=$(uuidgen | sed 's/-//g')
-    container_tag=$(sed 's/safe-//g' <<< "$component")
-    container_tag="$container_tag-$target"
-    [[ $build_type == "dev" ]] && container_tag="$container_tag-dev"
+    container_tag="$component-$target-$build_type"
     build_command=$(get_docker_build_command)
     docker run --name "$component-build-${uuid}" -v "$(pwd)":/usr/src/safe-cli:Z \
         -u "$(id -u)":"$(id -g)" \

--- a/resources/build-container.sh
+++ b/resources/build-container.sh
@@ -41,8 +41,7 @@ function get_dockerfile_name() {
     esac
 }
 
-tag="$(sed 's/safe-//g' <<< $component)-$target"
-[[ "$build_type" == "dev" ]] && tag="$tag-dev"
+tag="$component-$target-$build_type"
 rm -rf target/
 docker rmi -f maidsafe/safe-cli-build:"$tag"
 docker build -f $(get_dockerfile_name) -t maidsafe/safe-cli-build:"$tag" \

--- a/resources/get_release_description.sh
+++ b/resources/get_release_description.sh
@@ -68,22 +68,22 @@ s3_win_deploy_url="https:\/\/safe-cli.s3.amazonaws.com\/safe-cli-$version-x86_64
 s3_macos_deploy_url="https:\/\/safe-cli.s3.amazonaws.com\/safe-cli-$version-x86_64-apple-darwin-dev.zip"
 
 zip_linux_checksum=$(sha256sum \
-    "./deploy/real/safe-cli-$version-x86_64-unknown-linux-gnu.zip" | \
+    "./deploy/prod/safe-cli-$version-x86_64-unknown-linux-gnu.zip" | \
     awk '{ print $1 }')
 zip_macos_checksum=$(sha256sum \
-    "./deploy/real/safe-cli-$version-x86_64-apple-darwin.zip" | \
+    "./deploy/prod/safe-cli-$version-x86_64-apple-darwin.zip" | \
     awk '{ print $1 }')
 zip_win_checksum=$(sha256sum \
-    "./deploy/real/safe-cli-$version-x86_64-pc-windows-gnu.zip" | \
+    "./deploy/prod/safe-cli-$version-x86_64-pc-windows-gnu.zip" | \
     awk '{ print $1 }')
 tar_linux_checksum=$(sha256sum \
-    "./deploy/real/safe-cli-$version-x86_64-unknown-linux-gnu.tar.gz" | \
+    "./deploy/prod/safe-cli-$version-x86_64-unknown-linux-gnu.tar.gz" | \
     awk '{ print $1 }')
 tar_macos_checksum=$(sha256sum \
-    "./deploy/real/safe-cli-$version-x86_64-apple-darwin.tar.gz" | \
+    "./deploy/prod/safe-cli-$version-x86_64-apple-darwin.tar.gz" | \
     awk '{ print $1 }')
 tar_win_checksum=$(sha256sum \
-    "./deploy/real/safe-cli-$version-x86_64-pc-windows-gnu.tar.gz" | \
+    "./deploy/prod/safe-cli-$version-x86_64-pc-windows-gnu.tar.gz" | \
     awk '{ print $1 }')
 
 s3_ffi_dev_linux_deploy_url="https:\/\/safe-cli.s3.amazonaws.com\/safe-ffi-$version-x86_64-unknown-linux-gnu-dev.zip"

--- a/resources/package-deploy-artifacts.sh
+++ b/resources/package-deploy-artifacts.sh
@@ -61,7 +61,7 @@ function get_archive_name() {
     extension=$4
 
     archive_name="$component-$stamp-$target"
-    [[ "$type" == "mock" ]] && archive_name="$archive_name-dev"
+    [[ "$type" == "dev" ]] && archive_name="$archive_name-dev"
     archive_name="$archive_name.$extension"
     echo "$archive_name"
 }
@@ -98,7 +98,7 @@ function create_zip_archive() {
         "../../artifacts/$component/$type/$target/release/$distributable"
 }
 
-declare -a types=("mock" "real")
+declare -a types=("dev" "prod")
 for type in "${types[@]}"; do
     targets=($(ls -1 "artifacts/$component/$type"))
     for target in "${targets[@]}"

--- a/resources/retrieve-build-artifacts.sh
+++ b/resources/retrieve-build-artifacts.sh
@@ -11,7 +11,7 @@ if [[ -z "$SAFE_CLI_BRANCH" ]]; then
 fi
 
 S3_BUCKET=safe-jenkins-build-artifacts
-declare -a types=("mock" "real")
+declare -a types=("dev" "prod")
 declare -a components=("safe-cli" "safe-ffi")
 
 for component in "${components[@]}"; do

--- a/resources/tag.sh
+++ b/resources/tag.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+version=$1
+if [[ -z "$version" ]]; then
+    echo "You must supply a version number for the tag."
+    exit 1
+fi
+
+component=$2
+if [[ -z "$component" ]]; then
+    echo "You must supply the component to build."
+    echo "Valid values are 'safe-cli', 'safe-api' or 'safe-ffi'."
+    exit 1
+fi
+
+git config --global user.name "$GIT_USER"
+git config --global user.email qa@maidsafe.net
+git config credential.username "$GIT_USER"
+git config credential.helper "!f() { echo password=$GIT_PASSWORD; }; f"
+git tag -a "$version" -m "Creating tag for $version"
+GIT_ASKPASS=true git push origin --tags --no-verify


### PR DESCRIPTION
This transfers the build and release process from Jenkins to GitHub Actions. The entire process is replicated here, split into 2 workflows, PR and master.

The PR configuration will run the tests and build the mobile configurations. The master configuration will build everything, then deploy and publish. There are conditionals that check for the existence
of a version change message, as before. Since you have the same configuration for building mobile in both workflows, there's a lot of duplication here, but for now we're just accepting that as a limitation
of the Actions system.

This [release](https://github.com/jacderida/safe-cli/releases/tag/0.5.3) on my fork was done using Actions.

Due to an issue with rust_sodium, we are also missing macOS for the time being, but sodium should be removed fairly soon. I've left stuff commented, which you should be able to uncomment when macOS is ready again.