### PR TITLE
Pretty serialized output via --output 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2335,6 +2335,7 @@ dependencies = [
  "self_update 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "shrust 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/safe-cli/Cargo.toml
+++ b/safe-cli/Cargo.toml
@@ -35,6 +35,7 @@ safe-api = { path = "../safe-api" }
 self_update = "0.5.1"
 serde = "1.0.91"
 serde_json = "1.0.39"
+serde_yaml = "0.8.11"
 shrust = "0.0.7"
 structopt = "0.2.15"
 pretty-hex = "0.1.1"

--- a/safe-cli/cli.rs
+++ b/safe-cli/cli.rs
@@ -32,7 +32,7 @@ pub struct CmdArgs {
     // /// The account's Root Container address
     // #[structopt(long = "root", raw(global = "true"))]
     // root: bool,
-    /// Output data serialisation. Currently only supported 'json'
+    /// Output data serialisation: [json, jsonpretty, yaml]
     #[structopt(short = "o", long = "output", raw(global = "true"))]
     output_fmt: Option<String>,
     /// Sets JSON as output serialisation format (alias of '--output json')
@@ -79,6 +79,8 @@ pub fn run_with(cmd_args: &[&str], mut safe: &mut Safe) -> Result<(), String> {
         let fmt = args.output_fmt.clone().unwrap_or_else(|| "".to_string());
         match fmt.as_ref() {
             "json" => OutputFmt::Json,
+            "jsonpretty" => OutputFmt::JsonPretty,
+            "yaml" => OutputFmt::Yaml,
             "" => OutputFmt::Pretty,
             other => {
                 return Err(format!(

--- a/safe-cli/cli.rs
+++ b/safe-cli/cli.rs
@@ -32,7 +32,7 @@ pub struct CmdArgs {
     // /// The account's Root Container address
     // #[structopt(long = "root", raw(global = "true"))]
     // root: bool,
-    /// Output data serialisation: [json, jsonpretty, yaml]
+    /// Output data serialisation: [json, jsoncompact, yaml]
     #[structopt(short = "o", long = "output", raw(global = "true"))]
     output_fmt: Option<String>,
     /// Sets JSON as output serialisation format (alias of '--output json')
@@ -79,7 +79,7 @@ pub fn run_with(cmd_args: &[&str], mut safe: &mut Safe) -> Result<(), String> {
         let fmt = args.output_fmt.clone().unwrap_or_else(|| "".to_string());
         match fmt.as_ref() {
             "json" => OutputFmt::Json,
-            "jsonpretty" => OutputFmt::JsonPretty,
+            "jsoncompact" => OutputFmt::JsonCompact,
             "yaml" => OutputFmt::Yaml,
             "" => OutputFmt::Pretty,
             other => {

--- a/safe-cli/subcommands/cat.rs
+++ b/safe-cli/subcommands/cat.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::helpers::{get_from_arg_or_stdin,serialise_output};
+use super::helpers::{get_from_arg_or_stdin, serialise_output};
 use super::OutputFmt;
 use crate::operations::safe_net::connect;
 use log::debug;

--- a/safe-cli/subcommands/cat.rs
+++ b/safe-cli/subcommands/cat.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::helpers::{get_from_arg_or_stdin,serialize_output};
+use super::helpers::{get_from_arg_or_stdin,serialise_output};
 use super::OutputFmt;
 use crate::operations::safe_net::connect;
 use log::debug;
@@ -61,7 +61,7 @@ pub fn cat_commander(
                 });
                 table.printstd();
             } else {
-                println!("{}", serialize_output(&(url, files_map), output_fmt));
+                println!("{}", serialise_output(&(url, files_map), output_fmt));
             }
         }
         SafeData::PublishedImmutableData { data, .. } => {
@@ -87,7 +87,7 @@ pub fn cat_commander(
                 });
                 table.printstd();
             } else {
-                println!("{}", serialize_output(&(url, balances), output_fmt));
+                println!("{}", serialise_output(&(url, balances), output_fmt));
             }
         }
         SafeData::SafeKey { .. } => {

--- a/safe-cli/subcommands/cat.rs
+++ b/safe-cli/subcommands/cat.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::helpers::get_from_arg_or_stdin;
+use super::helpers::{get_from_arg_or_stdin,serialize_output};
 use super::OutputFmt;
 use crate::operations::safe_net::connect;
 use log::debug;
@@ -61,11 +61,7 @@ pub fn cat_commander(
                 });
                 table.printstd();
             } else {
-                println!(
-                    "{}",
-                    serde_json::to_string(&(url, files_map))
-                        .unwrap_or_else(|_| "Failed to serialise output to json".to_string())
-                );
+                println!("{}", serialize_output(&(url, files_map), output_fmt));
             }
         }
         SafeData::PublishedImmutableData { data, .. } => {
@@ -91,11 +87,7 @@ pub fn cat_commander(
                 });
                 table.printstd();
             } else {
-                println!(
-                    "{}",
-                    serde_json::to_string(&(url, balances))
-                        .unwrap_or_else(|_| "Failed to serialise output to json".to_string())
-                );
+                println!("{}", serialize_output(&(url, balances), output_fmt));
             }
         }
         SafeData::SafeKey { .. } => {

--- a/safe-cli/subcommands/dog.rs
+++ b/safe-cli/subcommands/dog.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::helpers::{get_from_arg_or_stdin, xorname_to_hex, serialise_output};
+use super::helpers::{get_from_arg_or_stdin, serialise_output, xorname_to_hex};
 use super::OutputFmt;
 use crate::operations::safe_net::connect;
 use log::debug;
@@ -59,7 +59,7 @@ pub fn dog_commander(
                         "type_tag": type_tag,
                         "xorname": xorname_to_hex(xorname)
                     }
-                ]); 
+                ]);
                 println!("{}", serialise_output(&jsonv, output_fmt));
             }
         }
@@ -89,7 +89,7 @@ pub fn dog_commander(
                         "media_type": media_type.clone().unwrap_or_else(|| "Unknown".to_string()),
                         "xorname": xorname_to_hex(xorname)
                     }
-                ]); 
+                ]);
                 println!("{}", serialise_output(&jsonv, output_fmt));
             }
         }
@@ -117,7 +117,7 @@ pub fn dog_commander(
                         "type_type": type_tag,
                         "xorname": xorname_to_hex(xorname)
                     }
-                ]); 
+                ]);
                 println!("{}", serialise_output(&jsonv, output_fmt));
             }
         }
@@ -140,7 +140,7 @@ pub fn dog_commander(
                         "data_type": "SafeKey",
                         "xorname": xorname_to_hex(xorname)
                     }
-                ]); 
+                ]);
                 println!("{}", serialise_output(&jsonv, output_fmt));
             }
         }

--- a/safe-cli/subcommands/dog.rs
+++ b/safe-cli/subcommands/dog.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::helpers::{get_from_arg_or_stdin, xorname_to_hex, serialize_output};
+use super::helpers::{get_from_arg_or_stdin, xorname_to_hex, serialise_output};
 use super::OutputFmt;
 use crate::operations::safe_net::connect;
 use log::debug;
@@ -49,7 +49,7 @@ pub fn dog_commander(
                 println!("XOR-URL: {}", xorurl);
                 print_resolved_from(100, resolved_from);
             } else if resolved_from.is_some() {
-                println!("{}", serialize_output(&(url, content), output_fmt));
+                println!("{}", serialise_output(&(url, content), output_fmt));
             } else {
                 let jsonv = serde_json::json!([
                     url,
@@ -60,7 +60,7 @@ pub fn dog_commander(
                         "xorname": xorname_to_hex(xorname)
                     }
                 ]); 
-                println!("{}", serialize_output(&jsonv, output_fmt));
+                println!("{}", serialise_output(&jsonv, output_fmt));
             }
         }
         SafeData::PublishedImmutableData {
@@ -80,7 +80,7 @@ pub fn dog_commander(
                 );
                 print_resolved_from(100, resolved_from);
             } else if resolved_from.is_some() {
-                println!("{}", serialize_output(&(url, content), output_fmt));
+                println!("{}", serialise_output(&(url, content), output_fmt));
             } else {
                 let jsonv = serde_json::json!([
                     url,
@@ -90,7 +90,7 @@ pub fn dog_commander(
                         "xorname": xorname_to_hex(xorname)
                     }
                 ]); 
-                println!("{}", serialize_output(&jsonv, output_fmt));
+                println!("{}", serialise_output(&jsonv, output_fmt));
             }
         }
         SafeData::Wallet {
@@ -108,7 +108,7 @@ pub fn dog_commander(
                 println!("XOR-URL: {}", xorurl);
                 print_resolved_from(100, resolved_from);
             } else if resolved_from.is_some() {
-                println!("{}", serialize_output(&(url, content), output_fmt));
+                println!("{}", serialise_output(&(url, content), output_fmt));
             } else {
                 let jsonv = serde_json::json!([
                     url,
@@ -118,7 +118,7 @@ pub fn dog_commander(
                         "xorname": xorname_to_hex(xorname)
                     }
                 ]); 
-                println!("{}", serialize_output(&jsonv, output_fmt));
+                println!("{}", serialise_output(&jsonv, output_fmt));
             }
         }
         SafeData::SafeKey {
@@ -132,7 +132,7 @@ pub fn dog_commander(
                 println!("XOR-URL: {}", xorurl);
                 print_resolved_from(100, resolved_from);
             } else if resolved_from.is_some() {
-                println!("{}", serialize_output(&(url, content), output_fmt));
+                println!("{}", serialise_output(&(url, content), output_fmt));
             } else {
                 let jsonv = serde_json::json!([
                     url,
@@ -141,7 +141,7 @@ pub fn dog_commander(
                         "xorname": xorname_to_hex(xorname)
                     }
                 ]); 
-                println!("{}", serialize_output(&jsonv, output_fmt));
+                println!("{}", serialise_output(&jsonv, output_fmt));
             }
         }
     }

--- a/safe-cli/subcommands/dog.rs
+++ b/safe-cli/subcommands/dog.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::helpers::{get_from_arg_or_stdin, xorname_to_hex};
+use super::helpers::{get_from_arg_or_stdin, xorname_to_hex, serialize_output};
 use super::OutputFmt;
 use crate::operations::safe_net::connect;
 use log::debug;
@@ -49,20 +49,18 @@ pub fn dog_commander(
                 println!("XOR-URL: {}", xorurl);
                 print_resolved_from(100, resolved_from);
             } else if resolved_from.is_some() {
-                println!(
-                    "{}",
-                    serde_json::to_string(&(&url, content))
-                        .unwrap_or_else(|_| "Failed to serialise output to json".to_string())
-                );
+                println!("{}", serialize_output(&(url, content), output_fmt));
             } else {
-                println!(
-                        "[{}, {{ \"data_type\": \"{}\", \"version\":\"{}\", \"type_tag\": \"{}\", \"xorname\": \"{}\" }}]",
-                        url,
-                        data_type,
-                        version,
-                        type_tag,
-                        xorname_to_hex(xorname),
-                );
+                let jsonv = serde_json::json!([
+                    url,
+                    {
+                        "data_type": data_type,
+                        "version": version,
+                        "type_tag": type_tag,
+                        "xorname": xorname_to_hex(xorname)
+                    }
+                ]); 
+                println!("{}", serialize_output(&jsonv, output_fmt));
             }
         }
         SafeData::PublishedImmutableData {
@@ -82,18 +80,17 @@ pub fn dog_commander(
                 );
                 print_resolved_from(100, resolved_from);
             } else if resolved_from.is_some() {
-                println!(
-                    "{}",
-                    serde_json::to_string(&(&url, content))
-                        .unwrap_or_else(|_| "Failed to serialise output to json".to_string())
-                );
+                println!("{}", serialize_output(&(url, content), output_fmt));
             } else {
-                println!(
-                    "[{}, {{ \"data_type\": \"PublishedImmutableData\", \"media_type\": \"{}\", \"xorname\": \"{}\" }}]",
+                let jsonv = serde_json::json!([
                     url,
-                    media_type.clone().unwrap_or_else(|| "Unknown".to_string()),
-                    xorname_to_hex(xorname),
-                );
+                    {
+                        "data_type": "PublishedImmutableData",
+                        "media_type": media_type.clone().unwrap_or_else(|| "Unknown".to_string()),
+                        "xorname": xorname_to_hex(xorname)
+                    }
+                ]); 
+                println!("{}", serialize_output(&jsonv, output_fmt));
             }
         }
         SafeData::Wallet {
@@ -111,19 +108,17 @@ pub fn dog_commander(
                 println!("XOR-URL: {}", xorurl);
                 print_resolved_from(100, resolved_from);
             } else if resolved_from.is_some() {
-                println!(
-                    "{}",
-                    serde_json::to_string(&(&url, content))
-                        .unwrap_or_else(|_| "Failed to serialise output to json".to_string())
-                );
+                println!("{}", serialize_output(&(url, content), output_fmt));
             } else {
-                println!(
-                    "[{}, {{ \"data_type\": \"{}\", \"type_tag\": \"{}\", \"xorname\": \"{}\" }}]",
+                let jsonv = serde_json::json!([
                     url,
-                    data_type,
-                    type_tag,
-                    xorname_to_hex(xorname),
-                );
+                    {
+                        "data_type": data_type,
+                        "type_type": type_tag,
+                        "xorname": xorname_to_hex(xorname)
+                    }
+                ]); 
+                println!("{}", serialize_output(&jsonv, output_fmt));
             }
         }
         SafeData::SafeKey {
@@ -137,17 +132,16 @@ pub fn dog_commander(
                 println!("XOR-URL: {}", xorurl);
                 print_resolved_from(100, resolved_from);
             } else if resolved_from.is_some() {
-                println!(
-                    "{}",
-                    serde_json::to_string(&(&url, content))
-                        .unwrap_or_else(|_| "Failed to serialise output to json".to_string())
-                );
+                println!("{}", serialize_output(&(url, content), output_fmt));
             } else {
-                println!(
-                    "[{}, {{ \"data_type\": \"SafeKey\", \"xorname\": \"{}\" }}]",
+                let jsonv = serde_json::json!([
                     url,
-                    xorname_to_hex(xorname),
-                );
+                    {
+                        "data_type": "SafeKey",
+                        "xorname": xorname_to_hex(xorname)
+                    }
+                ]); 
+                println!("{}", serialize_output(&jsonv, output_fmt));
             }
         }
     }

--- a/safe-cli/subcommands/files.rs
+++ b/safe-cli/subcommands/files.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::helpers::{get_from_arg_or_stdin, notice_dry_run, serialize_output};
+use super::helpers::{get_from_arg_or_stdin, notice_dry_run, serialise_output};
 use super::OutputFmt;
 use prettytable::{format::FormatBuilder, Table};
 use safe_api::{Safe, XorUrl, XorUrlEncoder};
@@ -229,7 +229,7 @@ fn print_serialized_output(
         }
         Err(_) => xorurl,
     };
-    println!("{}", serialize_output(&(url, processed_files), output_fmt));
+    println!("{}", serialise_output(&(url, processed_files), output_fmt));
 
     Ok(())
 }

--- a/safe-cli/subcommands/files.rs
+++ b/safe-cli/subcommands/files.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::helpers::{get_from_arg_or_stdin, notice_dry_run};
+use super::helpers::{get_from_arg_or_stdin, notice_dry_run, serialize_output};
 use super::OutputFmt;
 use prettytable::{format::FormatBuilder, Table};
 use safe_api::{Safe, XorUrl, XorUrlEncoder};
@@ -97,7 +97,7 @@ pub fn files_commander(
                 }
                 table.printstd();
             } else {
-                print_json_output(files_container_xorurl, 0, processed_files)?;
+                print_serialized_output(files_container_xorurl, 0, processed_files, output_fmt)?;
             }
 
             Ok(())
@@ -145,7 +145,7 @@ pub fn files_commander(
                     println!("No changes were required, source location is already in sync with FilesContainer (version {}) at: \"{}\"", version, target);
                 }
             } else {
-                print_json_output(target, version, processed_files)?;
+                print_serialized_output(target, version, processed_files, output_fmt)?;
             }
             Ok(())
         }
@@ -191,7 +191,7 @@ pub fn files_commander(
                     );
                 }
             } else {
-                print_json_output(target, version, processed_files)?;
+                print_serialized_output(target, version, processed_files, output_fmt)?;
             }
             Ok(())
         }
@@ -216,10 +216,11 @@ fn gen_processed_files_table(processed_files: &BTreeMap<String, (String, String)
     (table, success_count)
 }
 
-fn print_json_output(
+fn print_serialized_output(
     xorurl: XorUrl,
     version: u64,
     processed_files: BTreeMap<String, (String, String)>,
+    output_fmt: OutputFmt,
 ) -> Result<(), String> {
     let url = match XorUrlEncoder::from_url(&xorurl) {
         Ok(mut xorurl_encoder) => {
@@ -228,11 +229,7 @@ fn print_json_output(
         }
         Err(_) => xorurl,
     };
-    println!(
-        "{}",
-        serde_json::to_string(&(url, processed_files))
-            .unwrap_or_else(|_| "Failed to serialise output to json".to_string())
-    );
+    println!("{}", serialize_output(&(url, processed_files), output_fmt));
 
     Ok(())
 }

--- a/safe-cli/subcommands/helpers.rs
+++ b/safe-cli/subcommands/helpers.rs
@@ -90,20 +90,20 @@ pub fn parse_tx_id(src: &str) -> Result<u64, String> {
 }
 
 // serialize structured value using any format from OutputFmt
+// except OutputFmt::Pretty, which must be handled by caller.
 pub fn serialise_output<T: ?Sized>(value: &T, fmt: OutputFmt) -> String
 where
     T: Serialize,
 {
     match fmt {
+        OutputFmt::Yaml => serde_yaml::to_string(&value)
+            .unwrap_or_else(|_| "Failed to serialise output to yaml".to_string()),
         OutputFmt::Json => serde_json::to_string_pretty(&value)
             .unwrap_or_else(|_| "Failed to serialise output to json".to_string()),
         OutputFmt::JsonCompact => serde_json::to_string(&value)
             .unwrap_or_else(|_| "Failed to serialise output to json".to_string()),
-        OutputFmt::Yaml => serde_yaml::to_string(&value)
-            .unwrap_or_else(|_| "Failed to serialise output to yaml".to_string()),
         OutputFmt::Pretty => {
-            // For now we panic.  maybe make a default Pretty output later.
-            panic!("Pretty format must be handled by caller")
+            "OutputFmt::Pretty' not handled by caller, in serialise_output()".to_string()
         }
     }
 }

--- a/safe-cli/subcommands/helpers.rs
+++ b/safe-cli/subcommands/helpers.rs
@@ -6,11 +6,11 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use super::OutputFmt;
 use log::debug;
 use safe_api::XorName;
-use std::io::{self, stdin, stdout, Write};
-use super::OutputFmt;
 use serde::ser::Serialize;
+use std::io::{self, stdin, stdout, Write};
 
 // Warn the user about a dry-run being performed
 pub fn notice_dry_run() {
@@ -94,27 +94,16 @@ pub fn serialise_output<T: ?Sized>(value: &T, fmt: OutputFmt) -> String
 where
     T: Serialize,
 {
-
-    if fmt == OutputFmt::JsonPretty {
-        serde_json::to_string_pretty(&value)
-            .unwrap_or_else(|_| "Failed to serialise output to json".to_string())
+    match fmt {
+        OutputFmt::Json => serde_json::to_string_pretty(&value)
+            .unwrap_or_else(|_| "Failed to serialise output to json".to_string()),
+        OutputFmt::JsonCompact => serde_json::to_string(&value)
+            .unwrap_or_else(|_| "Failed to serialise output to json".to_string()),
+        OutputFmt::Yaml => serde_yaml::to_string(&value)
+            .unwrap_or_else(|_| "Failed to serialise output to yaml".to_string()),
+        OutputFmt::Pretty => {
+            // For now we panic.  maybe make a default Pretty output later.
+            panic!("Pretty format must be handled by caller")
+        }
     }
-    else if fmt == OutputFmt::Yaml {
-        serde_yaml::to_string(&value)
-            .unwrap_or_else(|_| "Failed to serialise output to yaml".to_string())
-    }
-    else if fmt == OutputFmt::Json {
-        serde_json::to_string(&value)
-            .unwrap_or_else(|_| "Failed to serialise output to json".to_string())
-    }
-    else if fmt == OutputFmt::Pretty {
-        // For now we panic.  maybe make a default Pretty output later.
-        panic!("Pretty format must be handled by caller")
-    }
-    else {
-        // We should only get in here if a new OutputFmt enum was added and not
-        // handled above.
-        panic!("Unable to serialize output.  Unknown format")
-    }
-
 }

--- a/safe-cli/subcommands/helpers.rs
+++ b/safe-cli/subcommands/helpers.rs
@@ -9,6 +9,8 @@
 use log::debug;
 use safe_api::XorName;
 use std::io::{self, stdin, stdout, Write};
+use super::OutputFmt;
+use serde::ser::Serialize;
 
 // Warn the user about a dry-run being performed
 pub fn notice_dry_run() {
@@ -85,4 +87,34 @@ pub fn get_secret_key(key_xorurl: &str, sk: Option<String>, msg: &str) -> Result
 pub fn parse_tx_id(src: &str) -> Result<u64, String> {
     src.parse::<u64>()
         .map_err(|err| format!("{}. A valid TX Id is a number between 0 and 2^64", err))
+}
+
+// serialize structured value using any format from OutputFmt
+pub fn serialize_output<T: ?Sized>(value: &T, fmt: OutputFmt) -> String
+where
+    T: Serialize,
+{
+
+    if fmt == OutputFmt::JsonPretty {
+        serde_json::to_string_pretty(&value)
+            .unwrap_or_else(|_| "Failed to serialise output to json".to_string())
+    }
+    else if fmt == OutputFmt::Yaml {
+        serde_yaml::to_string(&value)
+            .unwrap_or_else(|_| "Failed to serialise output to yaml".to_string())
+    }
+    else if fmt == OutputFmt::Json {
+        serde_json::to_string(&value)
+            .unwrap_or_else(|_| "Failed to serialise output to json".to_string())
+    }
+    else if fmt == OutputFmt::Pretty {
+        // For now we panic.  maybe make a default Pretty output later.
+        panic!("Pretty format must be handled by caller")
+    }
+    else {
+        // We should only get in here if a new OutputFmt enum was added and not
+        // handled above.
+        panic!("Unable to serialize output.  Unknown format")
+    }
+
 }

--- a/safe-cli/subcommands/helpers.rs
+++ b/safe-cli/subcommands/helpers.rs
@@ -90,7 +90,7 @@ pub fn parse_tx_id(src: &str) -> Result<u64, String> {
 }
 
 // serialize structured value using any format from OutputFmt
-pub fn serialize_output<T: ?Sized>(value: &T, fmt: OutputFmt) -> String
+pub fn serialise_output<T: ?Sized>(value: &T, fmt: OutputFmt) -> String
 where
     T: Serialize,
 {

--- a/safe-cli/subcommands/keys.rs
+++ b/safe-cli/subcommands/keys.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::helpers::{get_from_arg_or_stdin, get_secret_key, parse_tx_id};
+use super::helpers::{get_from_arg_or_stdin, get_secret_key, parse_tx_id, serialize_output};
 use super::OutputFmt;
 use crate::operations::safe_net::connect;
 use log::{debug, warn};
@@ -191,16 +191,8 @@ pub fn print_new_key_output(
             println!("Secret Key = {}", pair.sk);
         }
     } else if let Some(pair) = &key_pair {
-        println!(
-            "{}",
-            serde_json::to_string(&(&xorurl, pair))
-                .unwrap_or_else(|_| "Failed to serialise output to json".to_string())
-        );
+        println!("{}", serialize_output(&(&xorurl, pair), output_fmt));
     } else {
-        println!(
-            "{}",
-            serde_json::to_string(&xorurl)
-                .unwrap_or_else(|_| "Failed to serialise output to json".to_string())
-        );
+        println!("{}", serialize_output(&xorurl, output_fmt));
     }
 }

--- a/safe-cli/subcommands/keys.rs
+++ b/safe-cli/subcommands/keys.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::helpers::{get_from_arg_or_stdin, get_secret_key, parse_tx_id, serialize_output};
+use super::helpers::{get_from_arg_or_stdin, get_secret_key, parse_tx_id, serialise_output};
 use super::OutputFmt;
 use crate::operations::safe_net::connect;
 use log::{debug, warn};
@@ -191,8 +191,8 @@ pub fn print_new_key_output(
             println!("Secret Key = {}", pair.sk);
         }
     } else if let Some(pair) = &key_pair {
-        println!("{}", serialize_output(&(&xorurl, pair), output_fmt));
+        println!("{}", serialise_output(&(&xorurl, pair), output_fmt));
     } else {
-        println!("{}", serialize_output(&xorurl, output_fmt));
+        println!("{}", serialise_output(&xorurl, output_fmt));
     }
 }

--- a/safe-cli/subcommands/mod.rs
+++ b/safe-cli/subcommands/mod.rs
@@ -32,8 +32,8 @@ use structopt::StructOpt;
 pub enum OutputFmt {
     Pretty,
     Json,
-    JsonPretty,
-    Yaml
+    JsonCompact,
+    Yaml,
 }
 
 #[derive(StructOpt, Debug)]

--- a/safe-cli/subcommands/mod.rs
+++ b/safe-cli/subcommands/mod.rs
@@ -28,10 +28,12 @@ use auth::AuthSubCommands;
 
 use structopt::StructOpt;
 
-#[derive(PartialEq, Clone, Copy)]
+#[derive(PartialEq, Clone, Copy, Debug)]
 pub enum OutputFmt {
     Pretty,
     Json,
+    JsonPretty,
+    Yaml
 }
 
 #[derive(StructOpt, Debug)]

--- a/safe-cli/subcommands/nrs.rs
+++ b/safe-cli/subcommands/nrs.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::helpers::{get_from_arg_or_stdin, notice_dry_run, serialize_output};
+use super::helpers::{get_from_arg_or_stdin, notice_dry_run, serialise_output};
 use super::OutputFmt;
 use prettytable::{format::FormatBuilder, Table};
 use safe_api::{Safe, XorUrl};
@@ -156,6 +156,6 @@ fn print_summary(
         println!("{}: \"{}\"", header_msg, xorurl);
         table.printstd();
     } else {
-        println!("{}", serialize_output(&(xorurl, processed_entries), output_fmt));
+        println!("{}", serialise_output(&(xorurl, processed_entries), output_fmt));
     }
 }

--- a/safe-cli/subcommands/nrs.rs
+++ b/safe-cli/subcommands/nrs.rs
@@ -156,6 +156,9 @@ fn print_summary(
         println!("{}: \"{}\"", header_msg, xorurl);
         table.printstd();
     } else {
-        println!("{}", serialise_output(&(xorurl, processed_entries), output_fmt));
+        println!(
+            "{}",
+            serialise_output(&(xorurl, processed_entries), output_fmt)
+        );
     }
 }

--- a/safe-cli/subcommands/nrs.rs
+++ b/safe-cli/subcommands/nrs.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::helpers::{get_from_arg_or_stdin, notice_dry_run};
+use super::helpers::{get_from_arg_or_stdin, notice_dry_run, serialize_output};
 use super::OutputFmt;
 use prettytable::{format::FormatBuilder, Table};
 use safe_api::{Safe, XorUrl};
@@ -156,10 +156,6 @@ fn print_summary(
         println!("{}: \"{}\"", header_msg, xorurl);
         table.printstd();
     } else {
-        println!(
-            "{}",
-            serde_json::to_string(&(xorurl, processed_entries))
-                .unwrap_or_else(|_| "Failed to serialise output to json".to_string())
-        );
+        println!("{}", serialize_output(&(xorurl, processed_entries), output_fmt));
     }
 }

--- a/safe-cli/subcommands/wallet.rs
+++ b/safe-cli/subcommands/wallet.rs
@@ -8,7 +8,7 @@
 
 use structopt::StructOpt;
 
-use super::helpers::{get_from_arg_or_stdin, get_secret_key, parse_tx_id, serialize_output};
+use super::helpers::{get_from_arg_or_stdin, get_secret_key, parse_tx_id, serialise_output};
 use super::keys::{create_new_key, print_new_key_output};
 use super::OutputFmt;
 use log::debug;
@@ -154,9 +154,9 @@ pub fn wallet_commander(
                     );
                 }
             } else if let Some(pair) = &key_generated_output.1 {
-                println!("{}", serialize_output(&(&wallet_xorurl, &key_generated_output.0, pair), output_fmt));
+                println!("{}", serialise_output(&(&wallet_xorurl, &key_generated_output.0, pair), output_fmt));
             } else {
-                println!("{}", serialize_output(&(&wallet_xorurl, &key_generated_output.0), output_fmt));
+                println!("{}", serialise_output(&(&wallet_xorurl, &key_generated_output.0), output_fmt));
             }
 
             Ok(())

--- a/safe-cli/subcommands/wallet.rs
+++ b/safe-cli/subcommands/wallet.rs
@@ -154,9 +154,15 @@ pub fn wallet_commander(
                     );
                 }
             } else if let Some(pair) = &key_generated_output.1 {
-                println!("{}", serialise_output(&(&wallet_xorurl, &key_generated_output.0, pair), output_fmt));
+                println!(
+                    "{}",
+                    serialise_output(&(&wallet_xorurl, &key_generated_output.0, pair), output_fmt)
+                );
             } else {
-                println!("{}", serialise_output(&(&wallet_xorurl, &key_generated_output.0), output_fmt));
+                println!(
+                    "{}",
+                    serialise_output(&(&wallet_xorurl, &key_generated_output.0), output_fmt)
+                );
             }
 
             Ok(())

--- a/safe-cli/subcommands/wallet.rs
+++ b/safe-cli/subcommands/wallet.rs
@@ -8,7 +8,7 @@
 
 use structopt::StructOpt;
 
-use super::helpers::{get_from_arg_or_stdin, get_secret_key, parse_tx_id};
+use super::helpers::{get_from_arg_or_stdin, get_secret_key, parse_tx_id, serialize_output};
 use super::keys::{create_new_key, print_new_key_output};
 use super::OutputFmt;
 use log::debug;
@@ -154,17 +154,9 @@ pub fn wallet_commander(
                     );
                 }
             } else if let Some(pair) = &key_generated_output.1 {
-                println!(
-                    "{}",
-                    serde_json::to_string(&(&wallet_xorurl, &key_generated_output.0, pair))
-                        .unwrap_or_else(|_| "Failed to serialise output to json".to_string())
-                );
+                println!("{}", serialize_output(&(&wallet_xorurl, &key_generated_output.0, pair), output_fmt));
             } else {
-                println!(
-                    "{}",
-                    serde_json::to_string(&(&wallet_xorurl, &key_generated_output.0))
-                        .unwrap_or_else(|_| "Failed to serialise output to json".to_string())
-                );
+                println!("{}", serialize_output(&(&wallet_xorurl, &key_generated_output.0), output_fmt));
             }
 
             Ok(())

--- a/safe-cli/tests/cli_dog.rs
+++ b/safe-cli/tests/cli_dog.rs
@@ -63,6 +63,98 @@ fn calling_safe_dog_files_container_nrsurl() {
 }
 
 #[test]
+fn calling_safe_dog_files_container_nrsurl_jsoncompact() {
+    let content = cmd!(
+        get_bin_location(),
+        "files",
+        "put",
+        TEST_FILE,
+        "--output=jsoncompact"
+    )
+    .read()
+    .unwrap();
+    let (container_xorurl, _files_map) = parse_files_put_or_sync_output(&content);
+
+    let nrsurl = format!("safe://{}", get_random_nrs_string());
+    let _ = cmd!(
+        get_bin_location(),
+        "nrs",
+        "create",
+        &nrsurl,
+        "-l",
+        &container_xorurl,
+    )
+    .read()
+    .unwrap();
+
+    let dog_output = cmd!(get_bin_location(), "dog", &nrsurl, "--output=jsoncompact",)
+        .read()
+        .unwrap();
+
+    let content_info: (String, SafeData) = serde_json::from_str(&dog_output)
+        .expect("Failed to parse output of `safe dog` with -ii on file");
+    assert_eq!(content_info.0, nrsurl);
+    if let SafeData::FilesContainer { resolved_from, .. } = content_info.1 {
+        let unwrapped_resolved_from = resolved_from.unwrap();
+        assert_eq!(
+            unwrapped_resolved_from.public_name,
+            nrsurl.replace("safe://", "")
+        );
+        assert_eq!(unwrapped_resolved_from.type_tag, 1500);
+        assert_eq!(unwrapped_resolved_from.version, 0);
+        assert_eq!(
+            unwrapped_resolved_from.data_type,
+            SafeDataType::PublishedSeqAppendOnlyData
+        );
+    } else {
+        panic!("Content retrieved was unexpected: {:?}", content_info);
+    }
+}
+
+#[test]
+fn calling_safe_dog_files_container_nrsurl_yaml() {
+    let content = cmd!(get_bin_location(), "files", "put", TEST_FILE, "--json")
+        .read()
+        .unwrap();
+    let (container_xorurl, _files_map) = parse_files_put_or_sync_output(&content);
+
+    let nrsurl = format!("safe://{}", get_random_nrs_string());
+    let _ = cmd!(
+        get_bin_location(),
+        "nrs",
+        "create",
+        &nrsurl,
+        "-l",
+        &container_xorurl,
+    )
+    .read()
+    .unwrap();
+
+    let dog_output = cmd!(get_bin_location(), "dog", &nrsurl, "--output=yaml",)
+        .read()
+        .unwrap();
+
+    let content_info: (String, SafeData) = serde_yaml::from_str(&dog_output)
+        .expect("Failed to parse output of `safe dog` with -ii on file");
+    assert_eq!(content_info.0, nrsurl);
+    if let SafeData::FilesContainer { resolved_from, .. } = content_info.1 {
+        let unwrapped_resolved_from = resolved_from.unwrap();
+        assert_eq!(
+            unwrapped_resolved_from.public_name,
+            nrsurl.replace("safe://", "")
+        );
+        assert_eq!(unwrapped_resolved_from.type_tag, 1500);
+        assert_eq!(unwrapped_resolved_from.version, 0);
+        assert_eq!(
+            unwrapped_resolved_from.data_type,
+            SafeDataType::PublishedSeqAppendOnlyData
+        );
+    } else {
+        panic!("Content retrieved was unexpected: {:?}", content_info);
+    }
+}
+
+#[test]
 fn calling_safe_dog_safekey_nrsurl() {
     let (safekey_xorurl, _sk) = create_preload_and_get_keys("0");
 

--- a/safe-cli/tests/cli_dog.rs
+++ b/safe-cli/tests/cli_dog.rs
@@ -91,8 +91,8 @@ fn calling_safe_dog_files_container_nrsurl_jsoncompact() {
         .read()
         .unwrap();
 
-    let content_info: (String, SafeData) = serde_json::from_str(&dog_output)
-        .expect("Failed to parse output of `safe dog` with -ii on file");
+    let content_info: (String, SafeData) =
+        serde_json::from_str(&dog_output).expect("Failed to parse output of `safe dog`");
     assert_eq!(content_info.0, nrsurl);
     if let SafeData::FilesContainer { resolved_from, .. } = content_info.1 {
         let unwrapped_resolved_from = resolved_from.unwrap();
@@ -134,8 +134,8 @@ fn calling_safe_dog_files_container_nrsurl_yaml() {
         .read()
         .unwrap();
 
-    let content_info: (String, SafeData) = serde_yaml::from_str(&dog_output)
-        .expect("Failed to parse output of `safe dog` with -ii on file");
+    let content_info: (String, SafeData) =
+        serde_yaml::from_str(&dog_output).expect("Failed to parse output of `safe dog`");
     assert_eq!(content_info.0, nrsurl);
     if let SafeData::FilesContainer { resolved_from, .. } = content_info.1 {
         let unwrapped_resolved_from = resolved_from.unwrap();


### PR DESCRIPTION
Adds additional --output options: jsonpretty and yaml, eg:

```
OPTIONS:
    ...
    -o, --output <output_fmt>     Output data serialisation: [json, jsonpretty, yaml]
```

These serialization options make it much nicer to view structured data than raw/compact json, which remains the default.  All sub-commands use the new serialization options.  Some examples:

```
safe cat --output=jsonpretty safe://hnyynyiptjhhhzsicasjqhrdnmgu78bm4bcrj8o7q6qazai8sfj3kbt8nqbnc
[
  "safe://hnyynyiptjhhhzsicasjqhrdnmgu78bm4bcrj8o7q6qazai8sfj3kbt8nqbnc",
  {
    "/auth_and_connect.rs": {
      "created": "2019-11-21T08:41:23Z",
      "link": "safe://hbyyyynrmkqs4tn3bm9y57b7xr6tqaoca9e3insb9frkcs814h5r663pcy",
      "modified": "2019-11-21T08:41:23Z",
      "size": "3546",
      "type": "text/x-rust"
    },
    "/auth_daemon.rs": {
      "created": "2019-11-21T08:41:23Z",
      "link": "safe://hbyyyyda4ityjhafq6suqqdxkyc8c19ap6eyexbgczgajd3a5etaa4ijh3",
      "modified": "2019-11-21T08:41:23Z",
      "size": "13101",
      "type": "text/x-rust"
    }
  }
]
```

```
$ safe cat --output=yaml safe://hnyynyiptjhhhzsicasjqhrdnmgu78bm4bcrj8o7q6qazai8sfj3kbt8nqbnc 
---
- "safe://hnyynyiptjhhhzsicasjqhrdnmgu78bm4bcrj8o7q6qazai8sfj3kbt8nqbnc"
- /auth_and_connect.rs:
    created: "2019-11-21T08:41:23Z"
    link: "safe://hbyyyynrmkqs4tn3bm9y57b7xr6tqaoca9e3insb9frkcs814h5r663pcy"
    modified: "2019-11-21T08:41:23Z"
    size: "3546"
    type: text/x-rust
  /auth_daemon.rs:
    created: "2019-11-21T08:41:23Z"
    link: "safe://hbyyyyda4ityjhafq6suqqdxkyc8c19ap6eyexbgczgajd3a5etaa4ijh3"
    modified: "2019-11-21T08:41:23Z"
    size: "13101"
    type: text/x-rust
```

```
$ safe dog --output=jsonpretty safe://hnyynyiptjhhhzsicasjqhrdnmgu78bm4bcrj8o7q6qazai8sfj3kbt8nqbnc
[
  "safe://hnyynyiptjhhhzsicasjqhrdnmgu78bm4bcrj8o7q6qazai8sfj3kbt8nqbnc",
  {
    "data_type": "PublishedSeqAppendOnlyData",
    "type_tag": 1100,
    "version": 0,
    "xorname": "5b14f39cbdaacc592ee106259a7d3857a0b0893c3aef3b17c54f62a72a0c4e27"
  }
]
```
```
$ safe dog --output=json safe://hnyynyiptjhhhzsicasjqhrdnmgu78bm4bcrj8o7q6qazai8sfj3kbt8nqbnc
["safe://hnyynyiptjhhhzsicasjqhrdnmgu78bm4bcrj8o7q6qazai8sfj3kbt8nqbnc",{"data_type":"PublishedSeqAppendOnlyData","type_tag":1100,"version":0,"xorname":"5b14f39cbdaacc592ee106259a7d3857a0b0893c3aef3b17c54f62a72a0c4e27"}]
```
This last example was the only machine-readable way to serialize output before now and is not very human friendly.

#### Details
A new helper function is added: serialize_output() that takes a structured value and an OutputFmt enum, and serializes accordingly.  With this abstraction, we can easily add additional serializations supported by serde if desired.

This commit also fixes at least one json syntax error in dog.rs, where json was being manually constructed with strings and did not parse correctly. Now these values are constructed programmatically.

There is a new dependency on serde_yaml.

#### Testing
All existing test cases pass.  I have not yet written any new test cases specifically for the new output formats.

<!--
#### Thank you for contributing!

Please reference the issue(s) which this pull request addresses using [keywords](https://help.github.com/articles/closing-issues-using-keywords/) such as:

```
Resolves #452
Fixes #363
Closes #408
```

---

Provide QA team and reviewer steps to test the resolution.
For example:

```
QA:
Easiest way to test this PR would be to:
- Start authd
- login
- safe wallet insert <problem link>
- Expect to see an authentication error output

```

---

Commit messages should conform to the format:

```
<type>(<scope>): <description>

[optional body]

```

For example:

```
fix(auth): proper values returned on auth_decode_ipc_msg errors

  - Test case for authenticator error -208 IncompatibleMockStatus
  - Test case for authenticator error -103 when decoding share MData
    request for non-existent MData

```

Commit `type` can be one of:
**feat**: New feature
**fix**: Bug fix
**docs**: Documentation only changes
**style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
**refactor**: A code change that neither fixes a bug nor adds a feature
**perf**: A code change that improves performance
**test**: Adding missing tests
**chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation
**revert**: Reverting a feature, fix, or commit which introduces a regression or new bug

Commit `scope` is open to any succinct term which indicates the effected feature or component.

See [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)

---
Write your description below this line: -->
