### PR TITLE
chore(ci): strip jenkins down to macOS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,27 +10,9 @@ properties([
 ])
 
 stage('build & test') {
-    parallel(test_linux: {
-        node('safe_cli') {
-            checkout(scm)
-            runTests("cli")
-            packageBuildArtifacts("safe-cli", "dev", "x86_64-unknown-linux-gnu")
-            uploadBuildArtifacts()
-        }
-    },
-    test_cli_windows: {
-        node('windows') {
-            checkout(scm)
-            retrieveCache('windows')
-            runTests("cli")
-            packageBuildArtifacts("safe-cli", "dev", "x86_64-pc-windows-gnu")
-            uploadBuildArtifacts()
-        }
-    },
-    test_cli_macos: {
+    parallel(test_cli_macos: {
         node('osx') {
             checkout(scm)
-            retrieveCache('macos')
             runTests("cli")
             packageBuildArtifacts("safe-cli", "dev", "x86_64-apple-darwin")
             uploadBuildArtifacts()
@@ -42,28 +24,10 @@ stage('build & test') {
             runTests("api")
         }
     },
-    test_api_windows: {
-        node('windows') {
-            checkout(scm)
-            runTests("api")
-        }
-    },
-    test_api_linux: {
-        node('safe_cli') {
-            checkout(scm)
-            runTests("api")
-        }
-    },
-    clippy: {
-        node('safe_cli') {
-            checkout(scm)
-            sh("make clippy")
-        }
-    },
     ffi_ios_aarch64: {
         node('osx') {
             checkout(scm)
-            ["non-dev", "dev"].each({
+            ["prod", "dev"].each({
                 runReleaseBuild("safe-ffi", "${it}", "aarch64-apple-ios")
                 packageBuildArtifacts("safe-ffi", "${it}", "aarch64-apple-ios")
                 uploadBuildArtifacts()
@@ -73,7 +37,7 @@ stage('build & test') {
     ffi_ios_x86_64: {
         node('osx') {
             checkout(scm)
-            ["non-dev", "dev"].each({
+            ["prod", "dev"].each({
                 runReleaseBuild("safe-ffi", "${it}", "x86_64-apple-ios")
                 packageBuildArtifacts("safe-ffi", "${it}", "x86_64-apple-ios")
                 uploadBuildArtifacts()
@@ -83,7 +47,7 @@ stage('build & test') {
     ffi_macos: {
         node('osx') {
             checkout(scm)
-            ["non-dev", "dev"].each({
+            ["prod", "dev"].each({
                 runReleaseBuild("safe-ffi", "${it}", "x86_64-apple-darwin")
                 stripArtifacts()
                 packageBuildArtifacts("safe-ffi", "${it}", "x86_64-apple-darwin")
@@ -91,95 +55,15 @@ stage('build & test') {
             })
         }
     },
-    ffi_windows: {
-        node('windows') {
-            checkout(scm)
-            ["non-dev", "dev"].each({
-                runReleaseBuild("safe-ffi", "${it}", "x86_64-pc-windows-gnu")
-                packageBuildArtifacts("safe-ffi", "${it}", "x86_64-pc-windows-gnu")
-                uploadBuildArtifacts()
-            })
-        }
-    },
-    release_cli_linux: {
-        node('safe_cli') {
-            checkout(scm)
-            runReleaseBuild("safe-cli", "non-dev", "x86_64-unknown-linux-gnu")
-            stripArtifacts()
-            packageBuildArtifacts("safe-cli", "non-dev", "x86_64-unknown-linux-gnu")
-            uploadBuildArtifacts()
-        }
-    },
-    cli_windows: {
-        node('windows') {
-            checkout(scm)
-            ["non-dev", "dev"].each({
-                runReleaseBuild("safe-cli", "${it}", "x86_64-pc-windows-gnu")
-                stripArtifacts()
-                packageBuildArtifacts("safe-cli", "${it}", "x86_64-pc-windows-gnu")
-                uploadBuildArtifacts()
-            })
-        }
-    },
     cli_macos: {
         node('osx') {
             checkout(scm)
-            ["non-dev", "dev"].each({
+            ["prod", "dev"].each({
                 runReleaseBuild("safe-cli", "${it}", "x86_64-apple-darwin")
                 stripArtifacts()
                 packageBuildArtifacts("safe-cli", "${it}", "x86_64-apple-darwin")
                 uploadBuildArtifacts()
             })
-        }
-    },
-    release_ffi_linux: {
-        node('safe_cli') {
-            checkout(scm)
-            runReleaseBuild("safe-ffi", "non-dev", "x86_64-unknown-linux-gnu")
-            stripArtifacts()
-            packageBuildArtifacts("safe-ffi", "non-dev", "x86_64-unknown-linux-gnu")
-            uploadBuildArtifacts()
-        }
-    },
-    release_ffi_android_x86_64: {
-        node('safe_cli') {
-            checkout(scm)
-            runReleaseBuild("safe-ffi", "non-dev", "x86_64-linux-android")
-            packageBuildArtifacts("safe-ffi", "non-dev", "x86_64-linux-android")
-            uploadBuildArtifacts()
-        }
-    },
-    release_ffi_android_armv7: {
-        node('safe_cli') {
-            checkout(scm)
-            runReleaseBuild("safe-ffi", "non-dev", "armv7-linux-androideabi")
-            packageBuildArtifacts("safe-ffi", "non-dev", "armv7-linux-androideabi")
-            uploadBuildArtifacts()
-        }
-    },
-    dev_ffi_linux: {
-        node('safe_cli') {
-            checkout(scm)
-            runReleaseBuild("safe-ffi", "dev", "x86_64-unknown-linux-gnu")
-            stripArtifacts()
-            packageBuildArtifacts("safe-ffi", "dev", "x86_64-unknown-linux-gnu")
-            uploadBuildArtifacts()
-        }
-    },
-    dev_ffi_android_armv7: {
-        node('safe_cli') {
-            checkout(scm)
-            runReleaseBuild("safe-ffi", "dev", "armv7-linux-androideabi")
-            packageBuildArtifacts("safe-ffi", "dev", "armv7-linux-androideabi")
-            uploadBuildArtifacts()
-        }
-    },
-    dev_ffi_android_x86_64: {
-        node('safe_cli') {
-            checkout(scm)
-            runReleaseBuild("safe-ffi", "dev", "x86_64-linux-android")
-            packageBuildArtifacts("safe-ffi", "dev", "x86_64-linux-android")
-            uploadBuildArtifacts()
         }
     })
 }
@@ -190,6 +74,7 @@ stage("build universal iOS lib") {
         def branch = env.CHANGE_ID?.trim() ?: env.BRANCH_NAME
         withEnv(["SAFE_CLI_BRANCH=${branch}",
                  "SAFE_CLI_BUILD_NUMBER=${env.BUILD_NUMBER}"]) {
+            sh("make retrieve-ios-build-artifacts")
             sh("make universal-ios-lib")
             sh("make package-universal-ios-lib")
             uploadBuildArtifacts()
@@ -203,55 +88,11 @@ stage('deploy') {
             checkout(scm)
             sh("git fetch --tags --force")
             retrieveBuildArtifacts()
-            if (isVersionChangeCommit()) {
-                version = sh(
-                    returnStdout: true,
-                    script: "grep '^version' < safe-cli/Cargo.toml | head -n 1 | awk '{ print \$3 }' | sed 's/\"//g'").trim()
-                packageArtifactsForDeploy(true)
-                createTag(version)
-                createGithubRelease(version)
-                uploadDeployArtifacts("mock")
-                uploadDeployArtifacts("real")
-            } else {
-                packageArtifactsForDeploy(false)
-                uploadDeployArtifacts("mock")
-                uploadDeployArtifacts("real")
-            }
+            packageArtifactsForDeploy(false)
+            uploadDeployArtifacts("dev")
+            uploadDeployArtifacts("prod")
         } else {
             echo("${env.BRANCH_NAME} does not match the deployment branch. Nothing to do.")
-        }
-    }
-    if (env.BRANCH_NAME == "master") {
-        build(job: "../rust_cache_build-safe_api", wait: false)
-        build(job: "../docker_build-safe_api_build_container", wait: false)
-    }
-}
-
-stage("publishing") {
-    node("safe_cli") {
-        checkout(scm)
-        if (shouldPublish()) {
-            withCredentials(
-                [string(
-                    credentialsId: "crates_io_token", variable: "CRATES_IO_TOKEN")]) {
-                sh("make publish-api")
-            }
-        } else {
-            echo("Not publishing.")
-            echo("Not a version change commit or the publish branch doesn't match.")
-        }
-    }
-}
-
-def shouldPublish() {
-    return isVersionChangeCommit() && env.BRANCH_NAME == "${params.PUBLISH_BRANCH}"
-}
-
-def retrieveCache(os) {
-    if (!fileExists("target")) {
-        withEnv(["SAFE_CLI_BRANCH=${params.CACHE_BRANCH}",
-                 "SAFE_CLI_OS=${os}"]) {
-            sh("make retrieve-cache")
         }
     }
 }
@@ -284,46 +125,11 @@ def runTests(component) {
     }
 }
 
-def isVersionChangeCommit() {
-    shortCommitHash = sh(
-        returnStdout: true,
-        script: "git log -n 1 --no-merges --pretty=format:'%h'").trim()
-    message = sh(
-        returnStdout: true,
-        script: "git log --format=%B -n 1 ${shortCommitHash}").trim()
-    return message.startsWith("Version change")
-}
-
 def packageArtifactsForDeploy(isVersionCommit) {
     if (isVersionCommit) {
         sh("make package-version-artifacts-for-deploy")
     } else {
         sh("make package-commit_hash-artifacts-for-deploy")
-    }
-}
-
-def createTag(version) {
-    withCredentials(
-        [usernamePassword(
-            credentialsId: "github_maidsafe_qa_user_credentials",
-            usernameVariable: "GIT_USER",
-            passwordVariable: "GIT_PASSWORD")]) {
-        sh("git config --global user.name \$GIT_USER")
-        sh("git config --global user.email qa@maidsafe.net")
-        sh("git config credential.username \$GIT_USER")
-        sh("git config credential.helper '!f() { echo password=\$GIT_PASSWORD; }; f'")
-        sh("git tag -a ${version} -m 'Creating tag for ${version}'")
-        sh("GIT_ASKPASS=true git push origin --tags")
-    }
-}
-
-def createGithubRelease(version) {
-    withCredentials(
-        [usernamePassword(
-            credentialsId: "github_maidsafe_token_credentials",
-            usernameVariable: "GITHUB_USER",
-            passwordVariable: "GITHUB_TOKEN")]) {
-        sh("make deploy-github-release")
     }
 }
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ifndef SAFE_CLI_BUILD_COMPONENT
 endif
 ifndef SAFE_CLI_BUILD_TYPE
 	@echo "A build type must be specified."
-	@echo "Please set SAFE_CLI_BUILD_TYPE to 'dev' or 'non-dev'."
+	@echo "Please set SAFE_CLI_BUILD_TYPE to 'dev' or 'prod'."
 	@exit 1
 endif
 ifndef SAFE_CLI_BUILD_TARGET
@@ -38,7 +38,7 @@ endif
 
 build-all-containers:
 	SAFE_CLI_CONTAINER_TARGET=x86_64-unknown-linux-gnu \
-	SAFE_CLI_CONTAINER_TYPE=non-dev \
+	SAFE_CLI_CONTAINER_TYPE=prod \
 	SAFE_CLI_CONTAINER_COMPONENT=safe-cli \
 		make build-container
 	SAFE_CLI_CONTAINER_TARGET=x86_64-unknown-linux-gnu \
@@ -54,7 +54,7 @@ build-all-containers:
 	SAFE_CLI_CONTAINER_COMPONENT=safe-ffi \
 		make build-container
 	SAFE_CLI_CONTAINER_TARGET=x86_64-unknown-linux-gnu \
-	SAFE_CLI_CONTAINER_TYPE=non-dev \
+	SAFE_CLI_CONTAINER_TYPE=prod \
 	SAFE_CLI_CONTAINER_COMPONENT=safe-ffi \
 		make build-container
 	SAFE_CLI_CONTAINER_TARGET=x86_64-linux-android \
@@ -62,7 +62,7 @@ build-all-containers:
 	SAFE_CLI_CONTAINER_COMPONENT=safe-ffi \
 		make build-container
 	SAFE_CLI_CONTAINER_TARGET=x86_64-linux-android \
-	SAFE_CLI_CONTAINER_TYPE=non-dev \
+	SAFE_CLI_CONTAINER_TYPE=prod \
 	SAFE_CLI_CONTAINER_COMPONENT=safe-ffi \
 		make build-container
 	SAFE_CLI_CONTAINER_TARGET=armv7-linux-androideabi \
@@ -70,7 +70,7 @@ build-all-containers:
 	SAFE_CLI_CONTAINER_COMPONENT=safe-ffi \
 		make build-container
 	SAFE_CLI_CONTAINER_TARGET=armv7-linux-androideabi \
-	SAFE_CLI_CONTAINER_TYPE=non-dev \
+	SAFE_CLI_CONTAINER_TYPE=prod \
 	SAFE_CLI_CONTAINER_COMPONENT=safe-ffi \
 		make build-container
 
@@ -82,7 +82,7 @@ ifndef SAFE_CLI_CONTAINER_COMPONENT
 endif
 ifndef SAFE_CLI_CONTAINER_TYPE
 	@echo "A container type must be specified."
-	@echo "Please set SAFE_CLI_CONTAINER_TYPE to 'dev' or 'non-dev'."
+	@echo "Please set SAFE_CLI_CONTAINER_TYPE to 'dev' or 'prod'."
 	@exit 1
 endif
 ifndef SAFE_CLI_CONTAINER_TARGET
@@ -103,7 +103,7 @@ ifndef SAFE_CLI_CONTAINER_COMPONENT
 endif
 ifndef SAFE_CLI_CONTAINER_TYPE
 	@echo "A container type must be specified."
-	@echo "Please set SAFE_CLI_CONTAINER_TYPE to 'dev' or 'non-dev'."
+	@echo "Please set SAFE_CLI_CONTAINER_TYPE to 'dev' or 'prod'."
 	@exit 1
 endif
 ifndef SAFE_CLI_CONTAINER_TARGET
@@ -224,7 +224,7 @@ ifndef SAFE_CLI_BUILD_NUMBER
 endif
 ifndef SAFE_CLI_BUILD_TYPE
 	@echo "A value must be supplied for SAFE_CLI_BUILD_TYPE."
-	@echo "Valid values are 'dev' or 'non-dev'."
+	@echo "Valid values are 'dev' or 'prod'."
 	@exit 1
 endif
 ifndef SAFE_CLI_BUILD_COMPONENT
@@ -236,11 +236,7 @@ ifndef SAFE_CLI_BUILD_TARGET
 	@echo "A value must be supplied for SAFE_CLI_BUILD_TARGET."
 	@exit 1
 endif
-ifeq ($(SAFE_CLI_BUILD_TYPE),dev)
-	$(eval ARCHIVE_NAME := ${SAFE_CLI_BRANCH}-${SAFE_CLI_BUILD_NUMBER}-${SAFE_CLI_BUILD_COMPONENT}-${SAFE_CLI_BUILD_TARGET}-dev.tar.gz)
-else
-	$(eval ARCHIVE_NAME := ${SAFE_CLI_BRANCH}-${SAFE_CLI_BUILD_NUMBER}-${SAFE_CLI_BUILD_COMPONENT}-${SAFE_CLI_BUILD_TARGET}.tar.gz)
-endif
+	$(eval ARCHIVE_NAME := ${SAFE_CLI_BRANCH}-${SAFE_CLI_BUILD_NUMBER}-${SAFE_CLI_BUILD_COMPONENT}-${SAFE_CLI_BUILD_TYPE}-${SAFE_CLI_BUILD_TARGET}.tar.gz)
 	tar -C artifacts -zcvf ${ARCHIVE_NAME} .
 	rm artifacts/**
 	mv ${ARCHIVE_NAME} artifacts
@@ -258,8 +254,7 @@ ifndef SAFE_CLI_BUILD_NUMBER
 endif
 	rm -rf artifacts
 	./resources/retrieve-build-artifacts.sh \
-		"x86_64-unknown-linux-gnu" "x86_64-pc-windows-gnu" "x86_64-apple-darwin" \
-		"armv7-linux-androideabi" "x86_64-linux-android" "x86_64-apple-ios" \
+		"x86_64-apple-darwin" "x86_64-apple-ios" \
 		"aarch64-apple-ios" "apple-ios"
 	find artifacts -type d -empty -delete
 	rm -rf artifacts/safe-ffi/prod/aarch64-apple-ios
@@ -280,13 +275,13 @@ ifndef SAFE_CLI_BUILD_NUMBER
 endif
 	( \
 		cd artifacts; \
-		tar -C safe-ffi/real/universal -zcvf \
-			${SAFE_CLI_BRANCH}-${SAFE_CLI_BUILD_NUMBER}-safe-ffi-apple-ios.tar.gz .; \
+		tar -C safe-ffi/prod/universal -zcvf \
+			${SAFE_CLI_BRANCH}-${SAFE_CLI_BUILD_NUMBER}-safe-ffi-prod-apple-ios.tar.gz .; \
 	)
 	( \
 		cd artifacts; \
-		tar -C safe-ffi/mock/universal -zcvf \
-			${SAFE_CLI_BRANCH}-${SAFE_CLI_BUILD_NUMBER}-safe-ffi-apple-ios-dev.tar.gz .; \
+		tar -C safe-ffi/dev/universal -zcvf \
+			${SAFE_CLI_BRANCH}-${SAFE_CLI_BUILD_NUMBER}-safe-ffi-dev-apple-ios.tar.gz .; \
 	)
 	rm -rf artifacts/safe-ffi
 

--- a/resources/build-cache.sh
+++ b/resources/build-cache.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [[ -z "$build_type" ]]; then
-    echo "build_type must be set to dev or non-dev"
+    echo "build_type must be set to dev or prod"
     exit 1
 fi
 

--- a/resources/build-component.sh
+++ b/resources/build-component.sh
@@ -19,7 +19,7 @@ fi
 build_type=$3
 if [[ -z "$build_type" ]]; then
     echo "You must supply the type for the build."
-    echo "Valid values are 'dev' or 'non-dev'."
+    echo "Valid values are 'dev' or 'prod'."
     exit 1
 fi
 

--- a/resources/build-container.sh
+++ b/resources/build-container.sh
@@ -19,7 +19,7 @@ fi
 build_type=$3
 if [[ -z "$build_type" ]]; then
     echo "You must supply the type for the build."
-    echo "Valid values are 'dev' or 'non-dev'."
+    echo "Valid values are 'dev' or 'prod'."
     exit 1
 fi
 

--- a/resources/retrieve-build-artifacts.sh
+++ b/resources/retrieve-build-artifacts.sh
@@ -21,10 +21,7 @@ for component in "${components[@]}"; do
             mkdir -p "artifacts/$component/$type/$target/release"
             (
                 cd "artifacts/$component/$type/$target/release"
-                key="$SAFE_CLI_BRANCH-$SAFE_CLI_BUILD_NUMBER-$component-$target.tar.gz"
-                if [[ "$type" == "mock" ]]; then
-                    key="$SAFE_CLI_BRANCH-$SAFE_CLI_BUILD_NUMBER-$component-$target-dev.tar.gz"
-                fi
+                key="$SAFE_CLI_BRANCH-$SAFE_CLI_BUILD_NUMBER-$component-$type-$target.tar.gz"
                 # If the key being queried doesn't exist this check prints out an ugly error message
                 # that could potentially be confusing to people who are reading the logs.
                 # It's not a problem, so the output is suppressed.


### PR DESCRIPTION
This strips Jenkins down to just running the macOS build.

[This](https://jenkins.maidsafe.net/blue/organizations/jenkins/pipeline-safe_api/detail/PR-334/6/pipeline) build has a deployment.

```
2019-11-21 17:20:30   36049996 safe-ffi-a77d0d5-apple-ios-dev.zip
2019-11-21 17:20:30    4009475 safe-cli-a77d0d5-x86_64-apple-darwin-dev.zip
2019-11-21 17:20:31    5330170 safe-ffi-a77d0d5-x86_64-apple-darwin-dev.zip
2019-11-21 17:20:32   34576691 safe-ffi-a77d0d5-apple-ios.zip
2019-11-21 17:20:32    5242358 safe-cli-a77d0d5-x86_64-apple-darwin.zip
2019-11-21 17:20:33    6250799 safe-ffi-a77d0d5-x86_64-apple-darwin.zip
```