### PR TITLE
feat(cli): implemented `safe files add -` to read from stdin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2047,7 +2047,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "structopt",
+ "structopt 0.2.18",
  "tokio",
  "unwrap",
 ]
@@ -2604,7 +2604,7 @@ dependencies = [
  "serde_json",
  "slog",
  "slog-term",
- "structopt",
+ "structopt 0.2.18",
  "tokio",
  "tokio-current-thread",
  "tokio-reactor",
@@ -2641,7 +2641,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "shrust",
- "structopt",
+ "structopt 0.3.5",
  "unwrap",
 ]
 
@@ -3152,7 +3152,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
 dependencies = [
  "clap",
- "structopt-derive",
+ "structopt-derive 0.2.18",
+]
+
+[[package]]
+name = "structopt"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b3a3e93f5ad553c38b3301c8a0a0cec829a36783f6a0c467fc4bf553a5f5bf"
+dependencies = [
+ "clap",
+ "structopt-derive 0.3.5",
 ]
 
 [[package]]
@@ -3165,6 +3175,19 @@ dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
  "syn 0.15.44",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea692d40005b3ceba90a9fe7a78fa8d4b82b0ce627eebbffc329aab850f3410e"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2 1.0.7",
+ "quote 1.0.2",
+ "syn 1.0.13",
 ]
 
 [[package]]

--- a/safe-cli/Cargo.toml
+++ b/safe-cli/Cargo.toml
@@ -38,7 +38,7 @@ serde = "1.0.91"
 serde_json = "1.0.39"
 serde_yaml = "0.8.11"
 shrust = "0.0.7"
-structopt = "0.2.18"
+structopt = "~0.3.5"
 pretty-hex = "0.1.1"
 
 [features]

--- a/safe-cli/cli.rs
+++ b/safe-cli/cli.rs
@@ -28,34 +28,34 @@ use safe_api::{Safe, XorUrlBase};
 
 #[derive(StructOpt, Debug)]
 /// Interact with the SAFE Network
-#[structopt(raw(global_settings = "&[structopt::clap::AppSettings::ColoredHelp]"))]
+#[structopt(global_settings(&[structopt::clap::AppSettings::ColoredHelp]))]
 pub struct CmdArgs {
     /// subcommands
     #[structopt(subcommand)]
     pub cmd: Option<SubCommands>,
     // /// The account's Root Container address
-    // #[structopt(long = "root", raw(global = "true"))]
+    // #[structopt(long = "root", global(true))]
     // root: bool,
     /// Output data serialisation: [json, jsoncompact, yaml]
-    #[structopt(short = "o", long = "output", raw(global = "true"))]
+    #[structopt(short = "o", long = "output", global(true))]
     output_fmt: Option<OutputFmt>,
     /// Sets JSON as output serialisation format (alias of '--output json')
-    #[structopt(long = "json", raw(global = "true"))]
+    #[structopt(long = "json", global(true))]
     output_json: bool,
     // /// Increase output verbosity. (More logs!)
-    // #[structopt(short = "v", long = "verbose", raw(global = "true"))]
+    // #[structopt(short = "v", long = "verbose", global(true))]
     // verbose: bool,
     // /// Enable to query the output via SPARQL eg.
-    // #[structopt(short = "q", long = "query", raw(global = "true"))]
+    // #[structopt(short = "q", long = "query", global(true))]
     // query: Option<String>,
     /// Dry run of command. No data will be written. No coins spent
-    #[structopt(short = "n", long = "dry-run", raw(global = "true"))]
+    #[structopt(short = "n", long = "dry-run", global(true))]
     dry: bool,
     /// Base encoding to be used for XOR-URLs generated. Currently supported: base32z (default), base32 and base64
-    #[structopt(long = "xorurl", raw(global = "true"))]
+    #[structopt(long = "xorurl", global(true))]
     xorurl_base: Option<XorUrlBase>,
     /// Endpoint of the Authenticator daemon where to send requests to. If not provided, https://localhost:33000 is assumed.
-    #[structopt(long = "endpoint", raw(global = "true"))]
+    #[structopt(long = "endpoint", global(true))]
     pub endpoint: Option<String>,
 }
 

--- a/safe-cli/subcommands/files.rs
+++ b/safe-cli/subcommands/files.rs
@@ -7,8 +7,8 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::helpers::{
-    gen_processed_files_table, get_from_arg_or_stdin, get_from_stdin, notice_dry_run, parse_stdin_arg,
-    serialise_output,
+    gen_processed_files_table, get_from_arg_or_stdin, get_from_stdin, notice_dry_run,
+    parse_stdin_arg, serialise_output,
 };
 use super::OutputFmt;
 use prettytable::{format::FormatBuilder, Table};

--- a/safe-cli/subcommands/helpers.rs
+++ b/safe-cli/subcommands/helpers.rs
@@ -24,20 +24,27 @@ pub fn xorname_to_hex(xorname: &XorName) -> String {
     xorname.0.iter().map(|b| format!("{:02x}", b)).collect()
 }
 
-// Read the target location from the STDIN if is not an arg provided
-pub fn get_from_arg_or_stdin(
-    target_arg: Option<String>,
-    message: Option<&str>,
-) -> Result<String, String> {
-    match target_arg {
+// Read the argument string from the STDIN if is not an arg provided
+pub fn get_from_arg_or_stdin(arg: Option<String>, message: Option<&str>) -> Result<String, String> {
+    match arg {
         Some(ref t) if t.is_empty() => {
             let val = get_from_stdin(message)?;
-            Ok(String::from_utf8_lossy(&val).to_string())
+            Ok(String::from_utf8(val).map_err(|err| {
+                format!(
+                    "String read from STDIN contains invalid UTF-8 characters: {}",
+                    err
+                )
+            })?)
         }
         Some(t) => Ok(t),
         None => {
             let val = get_from_stdin(message)?;
-            Ok(String::from_utf8_lossy(&val).to_string())
+            Ok(String::from_utf8(val).map_err(|err| {
+                format!(
+                    "String read from STDIN contains invalid UTF-8 characters: {}",
+                    err
+                )
+            })?)
         }
     }
 }

--- a/safe-cli/subcommands/helpers.rs
+++ b/safe-cli/subcommands/helpers.rs
@@ -29,21 +29,25 @@ pub fn get_from_arg_or_stdin(
     target_arg: Option<String>,
     message: Option<&str>,
 ) -> Result<String, String> {
-    let the_message = message.unwrap_or_else(|| "...awaiting data from STDIN stream...");
     match target_arg {
+        Some(ref t) if t == "" => get_from_stdin(message),
         Some(t) => Ok(t),
-        None => {
-            println!("{}", &the_message);
-            let mut input = String::new();
-            match io::stdin().read_line(&mut input) {
-                Ok(n) => {
-                    debug!("Read ({} bytes) from STDIN: {}", n, input);
-                    input.truncate(input.len() - 1);
-                    Ok(input)
-                }
-                Err(_) => Err("Failed to read from STDIN stream".to_string()),
-            }
+        None => get_from_stdin(message),
+    }
+}
+
+// Outputs a message and then reads a single line from stdin
+pub fn get_from_stdin(message: Option<&str>) -> Result<String, String> {
+    let the_message = message.unwrap_or_else(|| "...awaiting data from STDIN stream...");
+    println!("{}", &the_message);
+    let mut input = String::new();
+    match io::stdin().read_line(&mut input) {
+        Ok(n) => {
+            debug!("Read ({} bytes) from STDIN: {}", n, input);
+            input.truncate(input.len() - 1);
+            Ok(input)
         }
+        Err(_) => Err("Failed to read from STDIN stream".to_string()),
     }
 }
 
@@ -113,6 +117,15 @@ pub fn gen_processed_files_table(
         }
     }
     (table, success_count)
+}
+
+// converts "-" to "", both of which mean to read from stdin.
+pub fn parse_stdin_arg(src: &str) -> String {
+    if src == "-" || src == "" {
+        "".to_string()
+    } else {
+        src.to_string()
+    }
 }
 
 // serialize structured value using any format from OutputFmt

--- a/safe-cli/subcommands/keys.rs
+++ b/safe-cli/subcommands/keys.rs
@@ -55,7 +55,7 @@ pub enum KeysSubCommands {
         #[structopt(long = "to")]
         to: Option<String>,
         /// The transaction ID, a random one will be generated if not provided. A valid TX Id is a number between 0 and 2^64
-        #[structopt(long = "tx-id", parse(try_from_str = "parse_tx_id"))]
+        #[structopt(long = "tx-id", parse(try_from_str = parse_tx_id))]
         tx_id: Option<u64>,
     },
 }

--- a/safe-cli/subcommands/wallet.rs
+++ b/safe-cli/subcommands/wallet.rs
@@ -83,7 +83,7 @@ pub enum WalletSubCommands {
         #[structopt(long = "to")]
         to: Option<String>,
         /// The transaction ID, a random one will be generated if not provided. A valid TX Id is a number between 0 and 2^64
-        #[structopt(long = "tx-id", parse(try_from_str = "parse_tx_id"))]
+        #[structopt(long = "tx-id", parse(try_from_str = parse_tx_id))]
         tx_id: Option<u64>,
     },
     /*#[structopt(name = "sweep")]


### PR DESCRIPTION
This PR enables reading from stdin for `safe files add` when `-` is specified as the location.

Example:

```
$ cat Cargo.toml | safe files add - safe://hnyynyww1tcm4dyoqcqr1t44uewi93xkmrbfqiontba5qyoethb7eucoqsbnc/Cargo.from_stdin.toml
FilesContainer updated (version 2): "safe://hnyynyww1tcm4dyoqcqr1t44uewi93xkmrbfqiontba5qyoethb7eucoqsbnc?v=2"
+  /Cargo.from_stdin.toml  safe://hbyyyydeok89zis7f8ca4ed64men66yo8ochfj8pror43k1xrq5hcxkwyq
```

and we can verify the content is correct:
```
$ safe cat safe://hbyyyydeok89zis7f8ca4ed64men66yo8ochfj8pror43k1xrq5hcxkwyq | md5sum
45d45fe602da3e3ba9099ed9579c922a  -
$ md5sum Cargo.toml 
45d45fe602da3e3ba9099ed9579c922a  Cargo.toml
```

Using `-` to indicate read from stdin is a common unix convention, eg used by the cat command.  However it does preclude uploading a file that is actually named `-`.

Anyway I figured I would submit the most basic/simple implementation first to see if the feature might be accepted, possibly with some tweaks.

I also looked at supporting stdin for the `safe files put` command, however that seems a bit trickier to implement as it calls `files_container_create` api, and there is no corresponding `files_container_create_from_raw()` api.   In the case of the `add` command, I called `files_container_add_from_raw()` with the stdin data.

<!--
#### Thank you for contributing!

Please reference the issue(s) which this pull request addresses using [keywords](https://help.github.com/articles/closing-issues-using-keywords/) such as:

```
Resolves #452
Fixes #363
Closes #408
```

---

Provide QA team and reviewer steps to test the resolution.
For example:

```
QA:
Easiest way to test this PR would be to:
- Start authd
- login
- safe wallet insert <problem link>
- Expect to see an authentication error output

```

---

Commit messages should conform to the format:

```
<type>(<scope>): <description>

[optional body]

```

For example:

```
fix(auth): proper values returned on auth_decode_ipc_msg errors

  - Test case for authenticator error -208 IncompatibleMockStatus
  - Test case for authenticator error -103 when decoding share MData
    request for non-existent MData

```

Commit `type` can be one of:
**feat**: New feature
**fix**: Bug fix
**docs**: Documentation only changes
**style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
**refactor**: A code change that neither fixes a bug nor adds a feature
**perf**: A code change that improves performance
**test**: Adding missing tests
**chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation
**revert**: Reverting a feature, fix, or commit which introduces a regression or new bug

Commit `scope` is open to any succinct term which indicates the effected feature or component.

See [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)

---
Write your description below this line: -->
