### PR TITLE
Add auth_app in ffi and rename connect to connect_app 

### DIFF
--- a/safe-api/src/api/auth.rs
+++ b/safe-api/src/api/auth.rs
@@ -23,9 +23,7 @@ const SAFE_AUTHD_METHOD_AUTHORISE: &str = "authorise";
 impl Safe {
     // Generate an authorisation request string and send it to a SAFE Authenticator.
     // It returns the credentials necessary to connect to the network, encoded in a single string.
-    #[cfg(not(any(target_os = "android", target_os = "androideabi", target_os = "ios")))]
     pub fn auth_app(
-        &mut self,
         app_id: &str,
         app_name: &str,
         app_vendor: &str,

--- a/safe-cli/operations/auth_and_connect.rs
+++ b/safe-cli/operations/auth_and_connect.rs
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 const AUTH_CREDENTIALS_FILENAME: &str = "credentials";
 
 pub fn authorise_cli(
-    safe: &mut Safe,
+    _safe: &mut Safe,
     endpoint: Option<String>,
     is_self_authing: bool,
 ) -> Result<(), String> {
@@ -30,14 +30,13 @@ pub fn authorise_cli(
         println!("Note you can use this CLI from another console to authorise it with 'auth allow' command. Alternativelly, you can also use '--self-auth' flag with 'auth login' command to automatically self authorise the CLI app.");
     }
     println!("Awaiting for authorising response from authd...");
-    let auth_credentials = safe
-        .auth_app(
-            APP_ID,
-            APP_NAME,
-            APP_VENDOR,
-            endpoint.as_ref().map(String::as_str),
-        )
-        .map_err(|err| format!("Application authorisation failed: {}", err))?;
+    let auth_credentials = Safe::auth_app(
+        APP_ID,
+        APP_NAME,
+        APP_VENDOR,
+        endpoint.as_ref().map(String::as_str),
+    )
+    .map_err(|err| format!("Application authorisation failed: {}", err))?;
 
     file.write_all(auth_credentials.as_bytes()).map_err(|err| {
         format!(

--- a/safe-ffi/ffi/mod.rs
+++ b/safe-ffi/ffi/mod.rs
@@ -26,7 +26,7 @@ use safe_api::Safe;
 use std::os::raw::{c_char, c_void};
 
 #[no_mangle]
-pub unsafe extern "C" fn connect(
+pub unsafe extern "C" fn connect_app(
     app_id: *const c_char,
     auth_credentials: *const c_char,
     user_data: *mut c_void,

--- a/safe-ffi/ffi/mod.rs
+++ b/safe-ffi/ffi/mod.rs
@@ -23,7 +23,34 @@ use errors::Result;
 use ffi_utils::{catch_unwind_cb, FfiResult, OpaqueCtx, ReprC, FFI_RESULT_OK};
 use helpers::from_c_str_to_str_option;
 use safe_api::Safe;
+use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
+
+#[no_mangle]
+pub unsafe extern "C" fn auth_app(
+    app_id: *const c_char,
+    app_name: *const c_char,
+    app_vendor: *const c_char,
+    endpoint: *const c_char,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        auth_response: *const c_char,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || -> Result<()> {
+        let user_data = OpaqueCtx(user_data);
+        let app_id = String::clone_from_repr_c(app_id)?;
+        let app_name = String::clone_from_repr_c(app_name)?;
+        let app_vendor = String::clone_from_repr_c(app_vendor)?;
+        let endpoint = from_c_str_to_str_option(endpoint);
+        let auth_response = Safe::auth_app(&app_id, &app_name, &app_vendor, endpoint)?;
+        let auth_response = CString::new(auth_response)?;
+        o_cb(user_data.0, FFI_RESULT_OK, auth_response.as_ptr());
+        Ok(())
+    })
+}
 
 #[no_mangle]
 pub unsafe extern "C" fn connect_app(


### PR DESCRIPTION
**Changes:**
- Add `auth_app` function in the `safe-ffi.
- Rename `connect` to the `connect_app` as it was causing an issue when loading the native lib on iOS.