### PR TITLE
chore(disconnect_notifier): update safe_api and safe_ffi to support d…

### DIFF
--- a/safe-api/src/api/app/auth.rs
+++ b/safe-api/src/api/app/auth.rs
@@ -83,8 +83,17 @@ impl Safe {
     }
 
     // Connect to the SAFE Network using the provided app id and auth credentials
-    pub fn connect(&mut self, app_id: &str, auth_credentials: Option<&str>) -> Result<()> {
-        self.safe_app.connect(app_id, auth_credentials)
+    pub fn connect<CB>(
+        &mut self,
+        app_id: &str,
+        auth_credentials: Option<&str>,
+        disconnect_notifier: Option<CB>,
+    ) -> Result<()>
+    where
+        CB: FnMut() + 'static + Send,
+    {
+        self.safe_app
+            .connect(app_id, auth_credentials, disconnect_notifier)
     }
 }
 

--- a/safe-api/src/api/app/fake_scl.rs
+++ b/safe-api/src/api/app/fake_scl.rs
@@ -121,7 +121,15 @@ impl SafeApp for SafeAppFake {
         Self { fake_vault }
     }
 
-    fn connect(&mut self, _app_id: &str, _auth_credentials: Option<&str>) -> Result<()> {
+    fn connect<CB>(
+        &mut self,
+        _app_id: &str,
+        _auth_credentials: Option<&str>,
+        _disconnect_cb: Option<CB>,
+    ) -> Result<()>
+    where
+        CB: FnMut() + 'static + Send,
+    {
         debug!("Using mock so there is no connection to network");
         Ok(())
     }

--- a/safe-api/src/api/app/fetch.rs
+++ b/safe-api/src/api/app/fetch.rs
@@ -83,7 +83,7 @@ impl Safe {
     /// # use safe_api::{Safe, fetch::SafeData};
     /// # use std::collections::BTreeMap;
     /// # let mut safe = Safe::default();
-    /// # safe.connect("", Some("fake-credentials")).unwrap();
+    /// # safe.connect("", Some("fake-credentials", Some(||()) ).unwrap();
     /// # async_std::task::block_on(async {
     ///     let (xorurl, _, _) = safe.files_container_create(Some("../testdata/"), None, true, false).await.unwrap();
     ///
@@ -121,7 +121,7 @@ impl Safe {
     /// # use safe_api::{Safe, fetch::SafeData};
     /// # use std::collections::BTreeMap;
     /// # let mut safe = Safe::default();
-    /// # safe.connect("", Some("fake-credentials")).unwrap();
+    /// # safe.connect("", Some("fake-credentials", Some(||()) ).unwrap();
     /// # async_std::task::block_on(async {
     ///     let (xorurl, _, _) = safe.files_container_create(Some("../testdata/"), None, true, false).await.unwrap();
     ///

--- a/safe-api/src/api/app/files.rs
+++ b/safe-api/src/api/app/files.rs
@@ -52,7 +52,7 @@ impl Safe {
     /// ```rust
     /// # use safe_api::Safe;
     /// # let mut safe = Safe::default();
-    /// # safe.connect("", Some("fake-credentials")).unwrap();
+    /// # safe.connect("", Some("fake-credentials", Some(||()) ).unwrap();
     /// let (xorurl, _processed_files, _files_map) = async_std::task::block_on(safe.files_container_create(Some("../testdata"), None, true, false)).unwrap();
     /// assert!(xorurl.contains("safe://"))
     /// ```
@@ -129,7 +129,7 @@ impl Safe {
     /// ```rust
     /// # use safe_api::Safe;
     /// # let mut safe = Safe::default();
-    /// # safe.connect("", Some("fake-credentials")).unwrap();
+    /// # safe.connect("", Some("fake-credentials", Some(||()) ).unwrap();
     /// # async_std::task::block_on(async {
     ///     let (xorurl, _processed_files, _files_map) = safe.files_container_create(Some("../testdata"), None, true, false).await.unwrap();
     ///     let (version, files_map) = safe.files_container_get(&xorurl).await.unwrap();
@@ -209,7 +209,7 @@ impl Safe {
     /// ```rust
     /// # use safe_api::Safe;
     /// # let mut safe = Safe::default();
-    /// # safe.connect("", Some("fake-credentials")).unwrap();
+    /// # safe.connect("", Some("fake-credentials", Some(||()) ).unwrap();
     /// # async_std::task::block_on(async {
     ///     let (xorurl, _processed_files, _files_map) = safe.files_container_create(Some("../testdata"), None, true, false).await.unwrap();
     ///     let (version, new_processed_files, new_files_map) = safe.files_container_sync("../testdata", &xorurl, true, false, false, false).await.unwrap();
@@ -299,7 +299,7 @@ impl Safe {
     /// ```rust
     /// # use safe_api::Safe;
     /// # let mut safe = Safe::default();
-    /// # safe.connect("", Some("fake-credentials")).unwrap();
+    /// # safe.connect("", Some("fake-credentials", Some(||()) ).unwrap();
     /// # async_std::task::block_on(async {
     ///     let (xorurl, _processed_files, _files_map) = safe.files_container_create(Some("../testdata"), None, true, false).await.unwrap();
     ///     let new_file_name = format!("{}/new_name_test.md", xorurl);
@@ -366,7 +366,7 @@ impl Safe {
     /// ```rust
     /// # use safe_api::Safe;
     /// # let mut safe = Safe::default();
-    /// # safe.connect("", Some("fake-credentials")).unwrap();
+    /// # safe.connect("", Some("fake-credentials", Some(||()) ).unwrap();
     /// # async_std::task::block_on(async {
     ///     let (xorurl, _processed_files, _files_map) = safe.files_container_create(Some("../testdata"), None, true, false).await.unwrap();
     ///     let new_file_name = format!("{}/new_name_test.md", xorurl);
@@ -417,7 +417,7 @@ impl Safe {
     /// ```rust
     /// # use safe_api::Safe;
     /// # let mut safe = Safe::default();
-    /// # safe.connect("", Some("fake-credentials")).unwrap();
+    /// # safe.connect("", Some("fake-credentials", Some(||()) ).unwrap();
     /// # async_std::task::block_on(async {
     ///     let (xorurl, processed_files, files_map) = safe.files_container_create(Some("../testdata/"), None, true, false).await.unwrap();
     ///     let remote_file_path = format!("{}/test.md", xorurl);
@@ -551,7 +551,7 @@ impl Safe {
     /// ```
     /// # use safe_api::Safe;
     /// # let mut safe = Safe::default();
-    /// # safe.connect("", Some("fake-credentials")).unwrap();
+    /// # safe.connect("", Some("fake-credentials", Some(||()) ).unwrap();
     /// # async_std::task::block_on(async {
     ///     let data = b"Something super good";
     ///     let xorurl = safe.files_put_published_immutable(data, Some("text/plain"), false).await.unwrap();
@@ -604,7 +604,7 @@ impl Safe {
     /// ```
     /// # use safe_api::Safe;
     /// # let mut safe = Safe::default();
-    /// # safe.connect("", Some("fake-credentials")).unwrap();
+    /// # safe.connect("", Some("fake-credentials", Some(||()) ).unwrap();
     /// # async_std::task::block_on(async {
     ///     let data = b"Something super good";
     ///     let xorurl = safe.files_put_published_immutable(data, None, false).await.unwrap();

--- a/safe-api/src/api/app/keys.rs
+++ b/safe-api/src/api/app/keys.rs
@@ -180,7 +180,7 @@ impl Safe {
     /// ```
     /// # use safe_api::Safe;
     /// let mut safe = Safe::default();
-    /// # safe.connect("", Some("fake-credentials")).unwrap();
+    /// # safe.connect("", Some("fake-credentials", Some(||()) ).unwrap();
     /// # async_std::task::block_on(async {
     ///     let (key1_xorurl, key_pair1) = safe.keys_create_preload_test_coins("14").await.unwrap();
     ///     let (key2_xorurl, key_pair2) = safe.keys_create_preload_test_coins("1").await.unwrap();

--- a/safe-api/src/api/app/nrs.rs
+++ b/safe-api/src/api/app/nrs.rs
@@ -128,7 +128,7 @@ impl Safe {
     /// # use rand::{thread_rng, Rng};
     /// # use safe_api::Safe;
     /// # let mut safe = Safe::default();
-    /// # safe.connect("", Some("fake-credentials")).unwrap();
+    /// # safe.connect("", Some("fake-credentials", Some(||()) ).unwrap();
     /// # async_std::task::block_on(async {
     ///     let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
     ///     let file_xorurl = safe.files_put_published_immutable(&vec![], None, false).await.unwrap();
@@ -241,7 +241,7 @@ impl Safe {
     /// # use rand::distributions::Alphanumeric;
     /// # use rand::{thread_rng, Rng};
     /// # let mut safe = Safe::default();
-    /// # safe.connect("", Some("fake-credentials")).unwrap();
+    /// # safe.connect("", Some("fake-credentials", Some(||()) ).unwrap();
     /// # async_std::task::block_on(async {
     ///     let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
     ///     let file_xorurl = safe.files_put_published_immutable(&vec![], Some("text/plain"), false).await.unwrap();

--- a/safe-api/src/api/app/safe_client_libs.rs
+++ b/safe-api/src/api/app/safe_client_libs.rs
@@ -83,7 +83,15 @@ impl SafeApp for SafeAppScl {
     }
 
     #[cfg(feature = "fake-auth")]
-    fn connect(&mut self, _app_id: &str, _auth_credentials: Option<&str>) -> Result<()> {
+    fn connect<CB>(
+        &mut self,
+        _app_id: &str,
+        _auth_credentials: Option<&str>,
+        _disconnect_cb: Option<CB>,
+    ) -> Result<()>
+    where
+        CB: FnMut() + 'static + Send,
+    {
         warn!("Using fake authorisation for testing...");
         self.safe_conn = Some(create_app());
         Ok(())

--- a/safe-api/src/api/app/safe_net.rs
+++ b/safe-api/src/api/app/safe_net.rs
@@ -20,7 +20,12 @@ pub type AppendOnlyDataRawData = (Vec<u8>, Vec<u8>);
 pub trait SafeApp {
     fn new() -> Self;
 
-    fn connect(&mut self, app_id: &str, auth_credentials: Option<&str>) -> Result<()>;
+    fn connect<CB: FnMut() + 'static + Send>(
+        &mut self,
+        app_id: &str,
+        auth_credentials: Option<&str>,
+        disconnect_cb: Option<CB>,
+    ) -> Result<()>;
 
     async fn create_balance(
         &mut self,

--- a/safe-api/src/api/app/test_helpers.rs
+++ b/safe-api/src/api/app/test_helpers.rs
@@ -14,7 +14,7 @@ use rand::{thread_rng, Rng};
 // Instantiate a Safe instance
 pub fn new_safe_instance() -> Result<Safe> {
     let mut safe = Safe::default();
-    safe.connect("", Some("fake-credentials"))?;
+    safe.connect("", Some("fake-credentials"), Some(|| ()))?;
     Ok(safe)
 }
 

--- a/safe-api/src/api/app/wallet.rs
+++ b/safe-api/src/api/app/wallet.rs
@@ -266,7 +266,7 @@ impl Safe {
     /// ```
     /// # use safe_api::Safe;
     /// let mut safe = Safe::default();
-    /// # safe.connect("", Some("fake-credentials")).unwrap();
+    /// # safe.connect("", Some("fake-credentials", Some(||()) ).unwrap();
     /// # async_std::task::block_on(async {
     ///     let wallet_xorurl = safe.wallet_create().await.unwrap();
     ///     let wallet_xorurl2 = safe.wallet_create().await.unwrap();
@@ -1318,7 +1318,7 @@ mod tests {
         .await?;
 
         let mut another_safe = Safe::default();
-        another_safe.connect("", Some("another-fake-credentials"))?;
+        another_safe.connect("", Some("another-fake-credentials"), Some(|| ()))?;
         let (key_xorurl, _key_pair) = another_safe.keys_create_preload_test_coins("100.5").await?;
 
         // test fail to transfer from a not owned wallet in <from> argument

--- a/safe-cli/operations/auth_and_connect.rs
+++ b/safe-cli/operations/auth_and_connect.rs
@@ -91,11 +91,13 @@ pub fn connect(safe: &mut Safe) -> Result<(), String> {
         info!("No credentials found for CLI, connecting with read-only access...");
     }
 
-    safe.connect(APP_ID, auth_credentials.as_deref(), None)
+    //Todo: fix this
+    let disconnect_cb: Option<Box<dyn FnMut() + Send + 'static>> = None;
+    safe.connect(APP_ID, auth_credentials.as_deref(), disconnect_cb)
         .or_else(|err| {
             if auth_credentials.is_some() {
                 warn!("Credentials found for CLI are invalid, connecting with read-only access...");
-                safe.connect(APP_ID, None, None)
+                safe.connect(APP_ID, None, disconnect_cb)
             } else {
                 Err(err)
             }

--- a/safe-cli/operations/auth_and_connect.rs
+++ b/safe-cli/operations/auth_and_connect.rs
@@ -91,11 +91,11 @@ pub fn connect(safe: &mut Safe) -> Result<(), String> {
         info!("No credentials found for CLI, connecting with read-only access...");
     }
 
-    safe.connect(APP_ID, auth_credentials.as_deref())
+    safe.connect(APP_ID, auth_credentials.as_deref(), None)
         .or_else(|err| {
             if auth_credentials.is_some() {
                 warn!("Credentials found for CLI are invalid, connecting with read-only access...");
-                safe.connect(APP_ID, None)
+                safe.connect(APP_ID, None, None)
             } else {
                 Err(err)
             }

--- a/safe-cli/operations/fake_auth.rs
+++ b/safe-cli/operations/fake_auth.rs
@@ -28,7 +28,7 @@ pub fn clear_credentials() -> Result<(), String> {
 pub fn connect(safe: &mut Safe) -> Result<(), String> {
     debug!("Fake-auth is enabled so we don't try to read the credentials file");
 
-    safe.connect(APP_ID, Some("fake-auth-credentials"))
+    safe.connect(APP_ID, Some("fake-auth-credentials"), Some(|| ()))
         .map_err(|err| {
             format!(
                 "Unexpected error when trying to connect with fake auth/network: {}",


### PR DESCRIPTION
…isconnect_notifier

**Testing pending locally**

<!--
#### Thank you for contributing!

Please reference the issue(s) which this pull request addresses using [keywords](https://help.github.com/articles/closing-issues-using-keywords/) such as:

```
Resolves #452
Fixes #363
Closes #408
```

---

Provide QA team and reviewer steps to test the resolution.
For example:

```
QA:
Easiest way to test this PR would be to:
- Start authd
- login
- safe wallet insert <problem link>
- Expect to see an authentication error output

```

---

Commit messages should conform to the format:

```
<type>(<scope>): <description>

[optional body]

```

For example:

```
fix(auth): proper values returned on auth_decode_ipc_msg errors

  - Test case for authenticator error -208 IncompatibleMockStatus
  - Test case for authenticator error -103 when decoding share MData
    request for non-existent MData

```

Commit `type` can be one of:
**feat**: New feature
**fix**: Bug fix
**docs**: Documentation only changes
**style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
**refactor**: A code change that neither fixes a bug nor adds a feature
**perf**: A code change that improves performance
**test**: Adding missing tests
**chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation
**revert**: Reverting a feature, fix, or commit which introduces a regression or new bug

Commit `scope` is open to any succinct term which indicates the effected feature or component.

See [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)

---
Write your description below this line: -->
