### PR TITLE
fix(fetch): Attempting to fetch felative asset from ID now fails.

### DIFF
--- a/safe-api/src/api/fetch.rs
+++ b/safe-api/src/api/fetch.rs
@@ -138,7 +138,8 @@ impl Safe {
 pub fn fetch_from_url(safe: &Safe, url: &str, retrieve_data: bool) -> Result<SafeData> {
     let mut the_xor = Safe::parse_url(url)?;
     let xorurl = the_xor.to_string()?;
-    info!("URL parsed successfully, fetching: {}", xorurl);
+    info!("URL parsed successfully, fetching: {:?}", xorurl);
+    info!("URL pars----------->>>: {:?}", the_xor);
     debug!("Fetching content of type: {:?}", the_xor.content_type());
 
     // TODO: pass option to get raw content AKA: Do not resolve beyond first thing.
@@ -171,6 +172,13 @@ pub fn fetch_from_url(safe: &Safe, url: &str, retrieve_data: bool) -> Result<Saf
         },
         SafeContentType::MediaType(media_type_str) => match the_xor.data_type() {
             SafeDataType::PublishedImmutableData => {
+                if !the_xor.path().is_empty() {
+                    return Err(Error::ContentError(format!(
+                        "Cannot get relative path of Immutable Data {:?}'",
+                        the_xor.path()
+                    )));
+                };
+
                 let data = if retrieve_data {
                     safe.files_get_published_immutable(&url)?
                 } else {

--- a/safe-cli/tests/cli_cat.rs
+++ b/safe-cli/tests/cli_cat.rs
@@ -24,6 +24,7 @@ use unwrap::unwrap;
 
 const TEST_FILE: &str = "../testdata/test.md";
 const TEST_FILE_CONTENT: &str = "hello tests!";
+const ID_RELATIVE_FILE_ERROR: &str = "Cannot get relative path of Immutable Data";
 const TEST_FILE_HEXDUMP_CONTENT: &str = "Length: 12 (0xc) bytes\n0000:   68 65 6c 6c  6f 20 74 65  73 74 73 21                hello tests!\n";
 const ANOTHER_FILE: &str = "../testdata/another.md";
 const ANOTHER_FILE_CONTENT: &str = "exists";
@@ -50,6 +51,23 @@ fn calling_safe_cat() {
         xorurl_encoder.data_type(),
         SafeDataType::PublishedImmutableData
     );
+}
+
+#[test]
+fn calling_safe_cat_on_relative_file_from_id_fails() {
+    let content = cmd!(get_bin_location(), "files", "put", TEST_FILE, "--json")
+        .read()
+        .unwrap();
+
+    let (_container_xorurl, map) = parse_files_put_or_sync_output(&content);
+    let mut cmd = Command::cargo_bin(CLI).unwrap();
+
+    let relative_url = format!("{}/something_relative.wasm", &map[TEST_FILE].1);
+    println!("Gettting xorurlll: {:?}", &relative_url);
+    cmd.args(&vec!["cat", &relative_url])
+        .assert()
+        .stderr(predicate::str::contains(ID_RELATIVE_FILE_ERROR))
+        .failure();
 }
 
 #[test]


### PR DESCRIPTION
fixes #403

<!--
#### Thank you for contributing!

Please reference the issue(s) which this pull request addresses using [keywords](https://help.github.com/articles/closing-issues-using-keywords/) such as:

```
Resolves #452
Fixes #363
Closes #408
```

---

Provide QA team and reviewer steps to test the resolution.
For example:

```
QA:
Easiest way to test this PR would be to:
- Start authd
- login
- safe wallet insert <problem link>
- Expect to see an authentication error output

```

---

Commit messages should conform to the format:

```
<type>(<scope>): <description>

[optional body]

```

For example:

```
fix(auth): proper values returned on auth_decode_ipc_msg errors

  - Test case for authenticator error -208 IncompatibleMockStatus
  - Test case for authenticator error -103 when decoding share MData
    request for non-existent MData

```

Commit `type` can be one of:
**feat**: New feature
**fix**: Bug fix
**docs**: Documentation only changes
**style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
**refactor**: A code change that neither fixes a bug nor adds a feature
**perf**: A code change that improves performance
**test**: Adding missing tests
**chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation
**revert**: Reverting a feature, fix, or commit which introduces a regression or new bug

Commit `scope` is open to any succinct term which indicates the effected feature or component.

See [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)

---
Write your description below this line: -->
