### PR TITLE
fix(update): set execution permissions to binary after installed/updated

### DIFF
--- a/resources/get_release_description.sh
+++ b/resources/get_release_description.sh
@@ -43,7 +43,7 @@ tar.gz: TAR_WIN_CHECKSUM
 ### SAFE Authenticator daemon
 
 The Authenticator daemon exposes services which allow applications and users to create SAFE Network accounts, log in using an existing account's credentials (passphrase and password), authorise applications which need to store data on the network on behalf of the user, as well as revoke permissions previously granted to applications.
-The SAFE Authenticator, which runs as a daemon or as a service in Windows platforms, can be started and managed with the SAFE CLI if the `safe-authd`/`safe-authd.exe` binary is in the system's PATH with execution permissions (please refer to [Authenticator section in CLI User Guide](https://github.com/maidsafe/safe-api/blob/master/safe-cli/README.md#the-authenticator-daemon-authd) for detailed instructions).
+The SAFE Authenticator, which runs as a daemon or as a service in Windows platforms, can be started and managed with the SAFE CLI if the `safe-authd`/`safe-authd.exe` binary is properly installed in the system with execution permissions. Please refer to [Authenticator section in CLI User Guide](https://github.com/maidsafe/safe-api/blob/master/safe-cli/README.md#the-authenticator-daemon-authd) for detailed instructions.
 
 | OS | Download link | SHA-256 checksum |
 | --- | --- | --- |

--- a/safe-cli/README.md
+++ b/safe-cli/README.md
@@ -219,7 +219,7 @@ Account was created successfully!
 
 #### Auth login
 
-Once you have a SAFE account created, we can login:
+When a new account is created with CLI, as we've seen above, the `authd` will stay logged into that same account. However if we want to log in to a different account, or to the same account after the PC or `authd` was restarted, we can login using the following command:
 ```shell
 $ safe auth login
 Passphrase:
@@ -228,7 +228,7 @@ Sending login action request to authd...
 Logged in successfully
 ```
 
-If we again send an status report request to `authd`, it should now show that it's logged in to a SAFE account:
+If we now send an status report request to `authd`, it should now show that it's logged in to a SAFE account:
 ```shell
 $ safe auth status
 Sending request to authd to obtain an status report...


### PR DESCRIPTION
This was not needed when extracting from a .tar.gz package, but it was missing for .zip packages.
We are now setting execution permissions after the binary was extracted regardless its
compression type, and we do it only on non-Windows platforms.