### PR TITLE
chore(cli): inform bash based system users that versioned URLs must b…

### DIFF
--- a/safe-cli/README.md
+++ b/safe-cli/README.md
@@ -450,7 +450,7 @@ Other optional args that can be used with `keys create` sub-command are:
 
 We can retrieve a given `SafeKey`'s balance simply using its secret key, which we can pass to `keys balance` subcommand with `--sk <secret key>` argument, or we can enter it when the CLI prompts us.
 
-We can optionally also pass the `SafeKey`'s XorUrl to have the CLI to verify they correspond to each other, i.e. if the `SafeKey`'s XorUrl is provided, the CLI will check if it corresponds to the public key derived from the passed secret key, and throw an error in it doesn't.
+We can optionally also pass the `SafeKey`'s XorUrl to have the CLI to verify they correspond to each other, i.e. if the `SafeKey`'s XorUrl is provided, the CLI will check if it corresponds to the public key derived from the passed secret key, and throw an error if it doesn't.
 
 The target `SafeKey`'s secret key can be passed as an argument (or it will be retrieved from `stdin`), let's check the balance of the `SafeKey` we created in previous section:
 ```bash
@@ -943,7 +943,7 @@ New NRS Map for "safe://mywebsite" created at: "safe://hnyydyz7utb6npt9kg3aksgor
 +  mywebsite  safe://hnyynyie8kccparz3pcxj9uisdc4gyzcpem9dfhehhjd6hpzwf8se5w1zobnc?v=0
 ```
 
-Note that we provided a versioned URL to the `--link` argument in the command above, i.e. a URL which targets a specific version of the content with `?v=<version number>`. Any type of content which can have different versions (like the case of a `FilesContainer` in our example) can be mapped/linked from an NRS name/subname only if a specific version is provided in the link URL.
+Note that we provided a versioned URL to the `--link` argument in the command above, i.e. a URL which targets a specific version of the content with `?v=<version number>`. Any type of content which can have different versions (like the case of a `FilesContainer` in our example) can be mapped/linked from an NRS name/subname only if a specific version is provided in the link URL. If you are using a bash based system and want to provide a version (or any other command containing a question mark), the URL must be wrapped in double quotes or bash will interpret the link as a file path and throw an error, e.g. use `"safe://hnyynyie8kccparz3pcxj9uisdc4gyzcpem9dfhehhjd6hpzwf8se5w1zobnc?v=0"`, not `safe://hnyynyie8kccparz3pcxj9uisdc4gyzcpem9dfhehhjd6hpzwf8se5w1zobncv=0`.
 
 We can now share the NRS-URL `safe://mywebsite` to anyone who wants to visit our website. Using this NRS-URL we can now fetch the same content we would do when using the `FilesContainer` XOR-URL we linked to it, thus we can fetch it using the following command:
 ```shell

--- a/safe-cli/subcommands/nrs.rs
+++ b/safe-cli/subcommands/nrs.rs
@@ -23,7 +23,7 @@ pub enum NrsSubCommands {
     Add {
         /// The name to add (or update if it already exists)
         name: String,
-        /// The safe:// URL to map this to. Usually a FilesContainer for a website
+        /// The safe:// URL to map this to. Usually a FilesContainer for a website. This should be wrapped in double quotes on bash based systems.
         #[structopt(short = "l", long = "link")]
         link: Option<String>,
         /// Set the sub name as default for this public name
@@ -38,7 +38,7 @@ pub enum NrsSubCommands {
     Create {
         /// The name to give site, eg 'safenetwork'
         name: String,
-        /// The safe:// URL to map this to. Usually a FilesContainer for a website
+        /// The safe:// URL to map this to. Usually a FilesContainer for a website. This should be wrapped in double quotes on bash based systems.
         #[structopt(short = "l", long = "link")]
         link: Option<String>,
         /// The default name is set using a direct link to the final destination that was provided with `--link`, rather than a link to the sub name being created (which is the default behaviour if this flag is not passed)


### PR DESCRIPTION
…e wrapped in quotes

At the moment if a user attempts to pass a versioned URL to `safe nrs create` on a bash / zsh based system, it will attempt to interpret the URL as a filepath and throw an error because the file path doesn't exist.

The `--help` documentation doesn't make it clear that the URLs must be passed wrapped in quotes. This is a bash bug and not a safe-api bug, but it's confusing and the majority of your users will be using a bash based system so it will save a lot of confusion down the road.

I also fixed a typo in the readme.md

QA:
Easiest way to test this PR would be to:
- Start a bash-based CLI program
- Start authd
- login
- safe nrs create NRS_NAME -l SAFE_LINK?v=0
- You will be presented with a bash error: `zsh: no matches found: SAFE_LINK?v=0`

---

- Start a bash-based CLI program
- Start authd
- login
- safe nrs create --help
- You will be presented with information informing you to wrap the SAFE_LINK in quotes