### PR TITLE
feat(cli): implements 'safe files tree' subcommand

### DIFF
--- a/safe-cli/Cargo.toml
+++ b/safe-cli/Cargo.toml
@@ -31,6 +31,8 @@ serde_yaml = "0.8.11"
 shrust = "0.0.7"
 structopt = "~0.3.5"
 pretty-hex = "0.1.1"
+ansi_term = "0.9.0"
+isatty = "0.1"
 
 [features]
 mock-network = ["safe-api/mock-network"]

--- a/safe-cli/subcommands/helpers.rs
+++ b/safe-cli/subcommands/helpers.rs
@@ -8,6 +8,7 @@
 // Software.
 
 use super::OutputFmt;
+use ansi_term::Style;
 use log::debug;
 use prettytable::{format::FormatBuilder, Table};
 use safe_api::XorName;
@@ -159,5 +160,25 @@ where
         OutputFmt::Pretty => {
             "OutputFmt::Pretty' not handled by caller, in serialise_output()".to_string()
         }
+    }
+}
+
+// returns singular or plural version of string, based on count.
+pub fn pluralize<'a>(singular: &'a str, plural: &'a str, count: u64) -> &'a str {
+    // pub fn pluralize(singular: &str, plural: &str, count: u64) -> String {
+    if count == 1 {
+        singular
+    } else {
+        plural
+    }
+}
+
+// if stdout is a TTY, then it returns a string with ansi codes according to
+// style.  Otherwise, it returns the original string.
+pub fn if_tty(s: &str, style: Style) -> String {
+    if isatty::stdout_isatty() {
+        style.paint(s).to_string()
+    } else {
+        s.to_string()
     }
 }

--- a/safe-cli/tests/common/mod.rs
+++ b/safe-cli/tests/common/mod.rs
@@ -116,6 +116,11 @@ pub fn parse_files_container_output(
 }
 
 #[allow(dead_code)]
+pub fn parse_files_tree_output(output: &str) -> serde_json::Value {
+    serde_json::from_str(output).expect("Failed to parse output of `safe tree`")
+}
+
+#[allow(dead_code)]
 pub fn parse_files_put_or_sync_output(
     output: &str,
 ) -> (String, BTreeMap<String, (String, String)>) {


### PR DESCRIPTION
This PR addresses #409. 

I added `safe files tree` subcommand, which displays output in same style as unix `tree` command, but without any color highlighting.  Serialized output is also available.

I included a flag `--flat` that causes the full tree to be displayed in a flat list, with full paths displayed as well as file details.  This was very easy to do because that is the format returned by files_container_get() API, so I just exposed it without any filtering.

Example output of `safe files tree`

```
$ safe files tree safe://hnyynysurwzoiudugs47d7fjx7hwg3i7ch1ryowdm7gpgj4538n1mwqukgbncsafe://hnyynysurwzoiudugs47d7fjx7hwg3i7ch1ryowdm7gpgj4538n1mwqukgbnc
├── another.md
├── noextension
├── subfolder
│   ├── sub2.md
│   └── subexists.md
└── test.md

$ safe files tree -o yaml safe://hnyynysurwzoiudugs47d7fjx7hwg3i7ch1ryowdm7gpgj4538n1mwqukgbnc
---
name: "safe://hnyynysurwzoiudugs47d7fjx7hwg3i7ch1ryowdm7gpgj4538n1mwqukgbnc"
sub:
  - name: another.md
  - name: noextension
  - name: subfolder
    sub:
      - name: sub2.md
      - name: subexists.md
  - name: test.md

$ safe files tree -o json safe://hnyynysurwzoiudugs47d7fjx7hwg3i7ch1ryowdm7gpgj4538n1mwqukgbnc
{
  "name": "safe://hnyynysurwzoiudugs47d7fjx7hwg3i7ch1ryowdm7gpgj4538n1mwqukgbnc",
  "sub": [
    {
      "name": "another.md"
    },
    {
      "name": "noextension"
    },
    {
      "name": "subfolder",
      "sub": [
        {
          "name": "sub2.md"
        },
        {
          "name": "subexists.md"
        }
      ]
    },
    {
      "name": "test.md"
    }
  ]
}
```

Example output of `safe files tree --flat`

```
$ safe files tree --flat safe://hnyynysurwzoiudugs47d7fjx7hwg3i7ch1ryowdm7gpgj4538n1mwqukgbnc
Files of FilesContainer (version 0) at "safe://hnyynysurwzoiudugs47d7fjx7hwg3i7ch1ryowdm7gpgj4538n1mwqukgbnc":
Total: 45
SIZE  CREATED               MODIFIED              NAME 
6     2020-03-03T22:31:21Z  2020-03-03T22:31:21Z  /another.md 
0     2020-03-03T22:31:21Z  2020-03-03T22:31:21Z  /noextension 
4     2020-03-03T22:31:21Z  2020-03-03T22:31:21Z  /subfolder/sub2.md 
23    2020-03-03T22:31:21Z  2020-03-03T22:31:21Z  /subfolder/subexists.md 
12    2020-03-03T22:31:21Z  2020-03-03T22:31:21Z  /test.md

$ safe files tree --flat --json safe://hnyynysurwzoiudugs47d7fjx7hwg3i7ch1ryowdm7gpgj4538n1mwqukgbnc 
{
  "/another.md": {
    "created": "2020-03-03T22:31:21Z",
    "link": "safe://hbhyrydt5b95dmumcm8yig4u1keuuh8hgsr5yx39xn4mqikp91sbdhbpwp",
    "modified": "2020-03-03T22:31:21Z",
    "size": "6",
    "type": "text/x-markdown"
  },
  "/noextension": {
    "created": "2020-03-03T22:31:21Z",
    "link": "safe://hbyyyynw7fi7ko8u3wtai6eekko3m5y6u9ud7w1i4ajycmwfwu3wwpnn81",
    "modified": "2020-03-03T22:31:21Z",
    "size": "0",
    "type": "Raw"
  },
  "/subfolder/sub2.md": {
    "created": "2020-03-03T22:31:21Z",
    "link": "safe://hbhyrydyr41tz98funce1eqzkgju8e1yb4343ppct4fiwie5n3qhsw7o7x",
    "modified": "2020-03-03T22:31:21Z",
    "size": "4",
    "type": "text/x-markdown"
  },
  "/subfolder/subexists.md": {
    "created": "2020-03-03T22:31:21Z",
    "link": "safe://hbhyryn9uodh1ju5uzyti3gmmtwburrssd89rcwcy3rzofdpypwomrzzte",
    "modified": "2020-03-03T22:31:21Z",
    "size": "23",
    "type": "text/x-markdown"
  },
  "/test.md": {
    "created": "2020-03-03T22:31:21Z",
    "link": "safe://hbhyrydpan7d94mwp1bun3mxfnrfrui131an7ihu11wsn8dkr8odab9qwn",
    "modified": "2020-03-03T22:31:21Z",
    "size": "12",
    "type": "text/x-markdown"
  }
}
```

**Testing**

I created a test case which tests output of `safe files tree` and `safe files tree --json` using the testdata directory.

**Notes**
* When using `--flat`, the paths are prefixed with '/'.  files_container_get() API returns them this way, and I think perhaps it should be modified to not do that.  The alternative is to copy/modify the list, which can be slow for very large trees.
* empty directories are not included in the list returned from files_container_get() even though one exists in the tree that was originally `safe files put`.  I will file an issue about this.
* The name of the root folder is displayed as a SAFE xorurl.  Yet it had a name when it was `safe files put`. So it seems we have lost information/structure.  If I use zip/unzip, tar/untar, cp -r, rsync, etc, I am able to preserve the root dirname.   I see no reason why `safe` should be different.  I will file an issue for this also.
* The implementation uses recursion to generate the tree.  This could blow up with a deep enough tree.  An iterative approach using a heap stack would be better.  I tried this initially and couldn't get it to work with the borrow checker.  Perhaps now that the recursive version works, it might be easier.  Anyway, I doubt the recursive version will run into any problems in the near future as people don't normally have directory structures thousands of levels deep.
* see additional notes/comments in the code.