### PR TITLE
feat(cli): implement a vault update command

### DIFF
--- a/safe-cli/README.md
+++ b/safe-cli/README.md
@@ -13,6 +13,7 @@
     - [Vault install](#vault-install)
     - [Run a local network](#run-a-local-network)
     - [Switch networks](#switch-networks)
+    - [Vault update](#vault-update)
   - [Auth](#auth)
     - [The Authenticator daemon (authd)](#the-authenticator-daemon-authd)
     - [Auth install](#auth-install)
@@ -253,6 +254,15 @@ Fetching 'shared-network' network connection information from 'https://safe-vaul
 ```
 
 Note that in the scenario that your current network is set to be the MaidSafe shared network, and that is restarted by MaidSafe (which causes new connection information to be published at the same URL), you then only need to re-run the `networks switch` command with the corresponding network name to update your system with the new connection information.
+
+#### Vault update
+
+The vault binary can be updated to the latest available version:
+```shell
+$ safe vault update
+```
+
+This command will check if a newer safe-vault release is available on [GitHub](https://github.com/maidsafe/safe_vault/releases). After prompting to confirm if you want to take the latest version, it will be downloaded and the binary will be updated. By default it will assume the safe-vault binary is at `~/.safe/vault/`, but you can override that path by providing `--vault-path <path>` argument to the above command.
 
 ### Auth
 

--- a/safe-cli/subcommands/vault.rs
+++ b/safe-cli/subcommands/vault.rs
@@ -16,7 +16,7 @@ const VAULTS_DATA_FOLDER: &str = "baby-fleming-vaults";
 #[derive(StructOpt, Debug)]
 pub enum VaultSubCommands {
     #[structopt(name = "install")]
-    /// Install latest safe-vault released version in the system.
+    /// Install latest safe-vault released version in the system
     Install {
         #[structopt(long = "vault-path")]
         /// Path where to install safe-vault executable (default ~/.safe/vault/). The SAFE_VAULT_PATH env var can be also used to set the path
@@ -43,6 +43,14 @@ pub enum VaultSubCommands {
         #[structopt(long = "vault-path", env = "SAFE_VAULT_PATH")]
         vault_path: Option<PathBuf>,
     },
+    #[structopt(name = "update")]
+    /// Update to latest safe-vault released version
+    Update {
+        #[structopt(long = "vault-path")]
+        /// Path of the safe-vault executable to update (default ~/.safe/vault/). The SAFE_VAULT_PATH env var can be also used to set the path
+        #[structopt(long = "vault-path", env = "SAFE_VAULT_PATH")]
+        vault_path: Option<PathBuf>,
+    },
 }
 
 pub fn vault_commander(cmd: Option<VaultSubCommands>) -> Result<(), String> {
@@ -59,6 +67,7 @@ pub fn vault_commander(cmd: Option<VaultSubCommands>) -> Result<(), String> {
             &interval.to_string(),
         ),
         Some(VaultSubCommands::Killall { vault_path }) => vault_shutdown(vault_path),
+        Some(VaultSubCommands::Update { vault_path }) => vault_update(vault_path),
         None => Err("Missing vault subcommand".to_string()),
     }
 }


### PR DESCRIPTION
This depends on a feature in safe-vault (https://github.com/maidsafe/safe_vault/pull/954), therefore we need to merge it only when there is a safe-vault release published which supports the `--update-only` flag.