### PR TITLE
feat(api): support for creation of empty FilesContainers with files_container_create API

### DIFF
--- a/safe-api/src/api/app/fetch.rs
+++ b/safe-api/src/api/app/fetch.rs
@@ -86,7 +86,7 @@ impl Safe {
     /// # let mut safe = Safe::default();
     /// # unwrap!(safe.connect("", Some("fake-credentials")));
     /// async_std::task::block_on(async {
-    ///     let (xorurl, _, _) = unwrap!(safe.files_container_create("../testdata/", None, true, false).await);
+    ///     let (xorurl, _, _) = unwrap!(safe.files_container_create(Some("../testdata/"), None, true, false).await);
     ///
     ///     let safe_data = unwrap!( safe.fetch( &format!( "{}/test.md", &xorurl.replace("?v=0", "") ), None ).await );
     ///     let data_string = match safe_data {
@@ -125,7 +125,7 @@ impl Safe {
     /// # let mut safe = Safe::default();
     /// # unwrap!(safe.connect("", Some("fake-credentials")));
     /// async_std::task::block_on(async {
-    ///     let (xorurl, _, _) = unwrap!(safe.files_container_create("../testdata/", None, true, false).await);
+    ///     let (xorurl, _, _) = unwrap!(safe.files_container_create(Some("../testdata/"), None, true, false).await);
     ///
     ///     let safe_data = unwrap!( safe.inspect( &format!( "{}/test.md", &xorurl.replace("?v=0", "") ) ).await );
     ///     let data_string = match safe_data {
@@ -548,7 +548,7 @@ mod tests {
         unwrap!(safe.connect("", Some("fake-credentials")));
         safe.connect("", Some("")).unwrap();
         let (xorurl, _, files_map) = unwrap!(
-            safe.files_container_create("../testdata/", None, true, false)
+            safe.files_container_create(Some("../testdata/"), None, true, false)
                 .await
         );
 
@@ -594,7 +594,7 @@ mod tests {
         safe.connect("", Some("")).unwrap();
 
         let (xorurl, _, the_files_map) = unwrap!(
-            safe.files_container_create("../testdata/", None, true, false)
+            safe.files_container_create(Some("../testdata/"), None, true, false)
                 .await
         );
 
@@ -647,7 +647,7 @@ mod tests {
         let mut safe = Safe::default();
         safe.connect("", Some("")).unwrap();
         let (xorurl, _, _the_files_map) = unwrap!(
-            safe.files_container_create("../testdata/", None, true, false)
+            safe.files_container_create(Some("../testdata/"), None, true, false)
                 .await
         );
 
@@ -772,7 +772,7 @@ mod tests {
         unwrap!(safe.connect("", Some("fake-credentials")));
 
         let (xorurl, _, _files_map) = unwrap!(
-            safe.files_container_create("../testdata/", None, true, false)
+            safe.files_container_create(Some("../testdata/"), None, true, false)
                 .await
         );
 

--- a/safe-cli/subcommands/files.rs
+++ b/safe-cli/subcommands/files.rs
@@ -184,7 +184,7 @@ pub async fn files_commander(
                 notice_dry_run();
             }
             let (files_container_xorurl, processed_files, _files_map) = safe
-                .files_container_create(&location, dest.as_deref(), recursive, dry_run)
+                .files_container_create(Some(&location), dest.as_deref(), recursive, dry_run)
                 .await?;
 
             // Now let's just print out a list of the files uploaded/processed

--- a/safe-cli/subcommands/xorurl.rs
+++ b/safe-cli/subcommands/xorurl.rs
@@ -67,7 +67,7 @@ pub async fn xorurl_commander(
 
             // Do a dry-run on the location
             let (_version, processed_files, _files_map) = safe
-                .files_container_create(&location, None, recursive, true)
+                .files_container_create(Some(&location), None, recursive, true)
                 .await?;
 
             // Now let's just print out a list of the xorurls

--- a/safe-ffi/ffi/files.rs
+++ b/safe-ffi/ffi/files.rs
@@ -38,10 +38,10 @@ pub unsafe extern "C" fn files_container_create(
 ) {
     catch_unwind_cb(user_data, o_cb, || -> Result<()> {
         let user_data = OpaqueCtx(user_data);
-        let location_str = String::clone_from_repr_c(location)?;
+        let location_opt = from_c_str_to_str_option(location);
         let destination = from_c_str_to_str_option(dest);
         let (xorurl, processed_files, files_map) = async_std::task::block_on(
-            (*app).files_container_create(&location_str, destination, recursive, dry_run),
+            (*app).files_container_create(location_opt, destination, recursive, dry_run),
         )?;
         let xorurl_string = CString::new(xorurl)?;
         let files_map_json = CString::new(serde_json::to_string(&files_map)?)?;


### PR DESCRIPTION
This is to cover one aspect of RFC #60 on Rust safe-api: https://github.com/maidsafe/rfcs/blob/master/text/0060-enable-creating-and-modifying-of-filescontainers-within-the-safe-browser-environment/0060-enable-creating-and-modifying-of-filescontainers-within-the-safe-browser-environment.md