### PR TITLE
feat/ffi: move logging API from safe_app to safe-ffi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3065,17 +3065,17 @@ dependencies = [
 name = "safe-ffi"
 version = "0.11.0"
 dependencies = [
- "async-std 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi_utils 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe-api 0.10.1",
- "safe-nd 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe_bindgen 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "safe_core 0.39.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-std",
+ "bincode",
+ "ffi_utils",
+ "log 0.4.8",
+ "safe-api",
+ "safe-nd",
+ "safe_bindgen",
+ "safe_core",
+ "serde",
+ "serde_json",
+ "unwrap",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3065,15 +3065,16 @@ dependencies = [
 name = "safe-ffi"
 version = "0.11.0"
 dependencies = [
- "async-std",
- "ffi_utils",
- "log 0.4.8",
- "safe-api",
- "safe-nd",
- "safe_bindgen",
- "serde",
- "serde_json",
- "unwrap",
+ "async-std 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi_utils 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safe-api 0.10.1",
+ "safe-nd 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safe_bindgen 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safe_core 0.39.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3066,6 +3066,7 @@ name = "safe-ffi"
 version = "0.11.0"
 dependencies = [
  "async-std 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi_utils 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-api 0.10.1",

--- a/safe-ffi/Cargo.toml
+++ b/safe-ffi/Cargo.toml
@@ -23,6 +23,7 @@ safe-nd = "^0.8.0"
 serde = "1.0.91"
 serde_json = "1.0.39"
 safe_core = "0.39.1"
+bincode = "~1.1.4"
 
 [dependencies.safe-api]
 path = "../safe-api"

--- a/safe-ffi/Cargo.toml
+++ b/safe-ffi/Cargo.toml
@@ -22,6 +22,7 @@ log = "~0.4.8"
 safe-nd = "^0.8.0"
 serde = "1.0.91"
 serde_json = "1.0.39"
+safe_core = "0.39.1"
 
 [dependencies.safe-api]
 path = "../safe-api"

--- a/safe-ffi/Cargo.toml
+++ b/safe-ffi/Cargo.toml
@@ -22,7 +22,7 @@ log = "~0.4.8"
 safe-nd = "^0.8.0"
 serde = "1.0.91"
 serde_json = "1.0.39"
-safe_core = "0.39.1"
+safe_core = "0.40.0"
 bincode = "~1.1.4"
 
 [dependencies.safe-api]

--- a/safe-ffi/ffi/errors.rs
+++ b/safe-ffi/ffi/errors.rs
@@ -7,8 +7,10 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
+use bincode::Error as SerialisationError;
 use ffi_utils::{ErrorCode, StringError};
 use safe_api::Error as NativeError;
+use safe_core::ipc::IpcError;
 use std::{ffi::NulError, fmt};
 
 mod codes {
@@ -87,6 +89,22 @@ impl ErrorCode for Error {
             Unexpected(ref _error) => ERR_UNEXPECTED_ERROR,
             Unknown(ref _error) => ERR_UNKNOWN_ERROR,
         }
+    }
+}
+
+impl From<IpcError> for Error {
+    fn from(err: IpcError) -> Self {
+        match err {
+            IpcError::EncodeDecodeError => Self(NativeError::AuthdError(format!("{:?}", err))),
+            IpcError::Unexpected(reason) => Self(NativeError::Unexpected(reason)),
+            _ => Self(NativeError::Unexpected(format!("{:?}", err))),
+        }
+    }
+}
+
+impl From<SerialisationError> for Error {
+    fn from(err: SerialisationError) -> Self {
+        Self(NativeError::Unexpected(format!("{:?}", err)))
     }
 }
 

--- a/safe-ffi/ffi/ipc.rs
+++ b/safe-ffi/ffi/ipc.rs
@@ -1,0 +1,268 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+use super::errors::{Error, Result};
+use bincode::serialize;
+use ffi_utils::ffi_error;
+use ffi_utils::{
+    catch_unwind_cb, vec_clone_from_raw_parts, FfiResult, NativeResult, ReprC, FFI_RESULT_OK,
+};
+use safe_core::ffi::ipc::req::{AuthReq, ContainersReq, ShareMDataRequest};
+use safe_core::ffi::ipc::resp::AuthGranted;
+use safe_core::ipc::{
+    self, AuthReq as NativeAuthReq, ContainersReq as NativeContainersReq, IpcError, IpcMsg, IpcReq,
+    IpcResp, ShareMDataReq as NativeShareMDataReq,
+};
+use std::ffi::CString;
+use std::os::raw::{c_char, c_void};
+
+/// Encode `AuthReq`.
+#[no_mangle]
+pub unsafe extern "C" fn encode_auth_req(
+    req: *const AuthReq,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        req_id: u32,
+        encoded: *const c_char,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || -> Result<_> {
+        let req_id = ipc::gen_req_id();
+        let req = NativeAuthReq::clone_from_repr_c(req)?;
+
+        let encoded = encode_ipc(req_id, IpcReq::Auth(req))?;
+        o_cb(user_data, FFI_RESULT_OK, req_id, encoded.as_ptr());
+        Ok(())
+    })
+}
+
+/// Encode `ContainersReq`.
+#[no_mangle]
+pub unsafe extern "C" fn encode_containers_req(
+    req: *const ContainersReq,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        req_id: u32,
+        encoded: *const c_char,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || -> Result<_> {
+        let req_id = ipc::gen_req_id();
+        let req = NativeContainersReq::clone_from_repr_c(req)?;
+
+        let encoded = encode_ipc(req_id, IpcReq::Containers(req))?;
+        o_cb(user_data, FFI_RESULT_OK, req_id, encoded.as_ptr());
+        Ok(())
+    })
+}
+
+/// Encode `AuthReq` for an unregistered client.
+#[no_mangle]
+pub unsafe extern "C" fn encode_unregistered_req(
+    extra_data: *const u8,
+    extra_data_len: usize,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        req_id: u32,
+        encoded: *const c_char,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || -> Result<_> {
+        let data = vec_clone_from_raw_parts(extra_data, extra_data_len);
+
+        let req_id = ipc::gen_req_id();
+        let encoded = encode_ipc(req_id, IpcReq::Unregistered(data))?;
+        o_cb(user_data, FFI_RESULT_OK, req_id, encoded.as_ptr());
+        Ok(())
+    })
+}
+
+/// Encode `ShareMDataReq`.
+#[no_mangle]
+pub unsafe extern "C" fn encode_share_mdata_req(
+    req: *const ShareMDataRequest,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(
+        user_data: *mut c_void,
+        result: *const FfiResult,
+        req_id: u32,
+        encoded: *const c_char,
+    ),
+) {
+    catch_unwind_cb(user_data, o_cb, || -> Result<_> {
+        let req_id = ipc::gen_req_id();
+        let req = NativeShareMDataReq::clone_from_repr_c(req)?;
+
+        let encoded = encode_ipc(req_id, IpcReq::ShareMData(req))?;
+        o_cb(user_data, FFI_RESULT_OK, req_id, encoded.as_ptr());
+        Ok(())
+    })
+}
+
+fn encode_ipc(req_id: u32, req: IpcReq) -> Result<CString> {
+    let encoded = ipc::encode_msg(&IpcMsg::Req {
+        req_id,
+        request: req,
+    })?;
+    Ok(CString::new(encoded)?)
+}
+
+/// Decode IPC message.
+#[no_mangle]
+pub unsafe extern "C" fn decode_ipc_msg(
+    msg: *const c_char,
+    user_data: *mut c_void,
+    o_auth: extern "C" fn(user_data: *mut c_void, req_id: u32, auth_granted: *const AuthGranted),
+    o_unregistered: extern "C" fn(
+        user_data: *mut c_void,
+        req_id: u32,
+        serialised_cfg: *const u8,
+        serialised_cfg_len: usize,
+    ),
+    o_containers: extern "C" fn(user_data: *mut c_void, req_id: u32),
+    o_share_mdata: extern "C" fn(user_data: *mut c_void, req_id: u32),
+    o_revoked: extern "C" fn(user_data: *mut c_void),
+    o_err: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, req_id: u32),
+) {
+    catch_unwind_cb(user_data, o_err, || -> Result<_> {
+        let msg = String::clone_from_repr_c(msg)?;
+        let msg = ipc::decode_msg(&msg)?;
+
+        decode_ipc_msg_impl(
+            msg,
+            user_data,
+            o_auth,
+            o_unregistered,
+            o_containers,
+            o_share_mdata,
+            o_revoked,
+            o_err,
+        )?;
+
+        Ok(())
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn decode_ipc_msg_impl(
+    msg: IpcMsg,
+    user_data: *mut c_void,
+    o_auth: extern "C" fn(user_data: *mut c_void, req_id: u32, auth_granted: *const AuthGranted),
+    o_unregistered: extern "C" fn(
+        user_data: *mut c_void,
+        req_id: u32,
+        serialised_cfg: *const u8,
+        serialised_cfg_len: usize,
+    ),
+    o_containers: extern "C" fn(user_data: *mut c_void, req_id: u32),
+    o_share_mdata: extern "C" fn(user_data: *mut c_void, req_id: u32),
+    o_revoked: extern "C" fn(user_data: *mut c_void),
+    o_err: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, req_id: u32),
+) -> Result<()> {
+    match msg {
+        IpcMsg::Resp {
+            response: IpcResp::Auth(res),
+            req_id,
+        } => match res {
+            Ok(auth_granted) => match auth_granted.into_repr_c() {
+                Ok(auth_granted) => {
+                    o_auth(user_data, req_id, &auth_granted);
+                }
+                Err(err) => {
+                    let e = Error::from(err);
+                    let (error_code, description) = ffi_error!(e);
+                    let res = NativeResult {
+                        error_code,
+                        description: Some(description),
+                    }
+                    .into_repr_c()?;
+                    o_err(user_data, &res, req_id);
+                }
+            },
+            Err(err) => {
+                let e = Error::from(err);
+                let (error_code, description) = ffi_error!(e);
+                let res = NativeResult {
+                    error_code,
+                    description: Some(description),
+                }
+                .into_repr_c()?;
+                o_err(user_data, &res, req_id);
+            }
+        },
+        IpcMsg::Resp {
+            response: IpcResp::Containers(res),
+            req_id,
+        } => match res {
+            Ok(()) => o_containers(user_data, req_id),
+            Err(err) => {
+                let e = Error::from(err);
+                let (error_code, description) = ffi_error!(e);
+                let res = NativeResult {
+                    error_code,
+                    description: Some(description),
+                }
+                .into_repr_c()?;
+                o_err(user_data, &res, req_id);
+            }
+        },
+        IpcMsg::Resp {
+            response: IpcResp::Unregistered(res),
+            req_id,
+        } => match res {
+            Ok(bootstrap_cfg) => {
+                let serialised_cfg = serialize(&bootstrap_cfg)?;
+                o_unregistered(
+                    user_data,
+                    req_id,
+                    serialised_cfg.as_ptr(),
+                    serialised_cfg.len(),
+                );
+            }
+            Err(err) => {
+                let e = Error::from(err);
+                let (error_code, description) = ffi_error!(e);
+                let res = NativeResult {
+                    error_code,
+                    description: Some(description),
+                }
+                .into_repr_c()?;
+                o_err(user_data, &res, req_id);
+            }
+        },
+        IpcMsg::Resp {
+            response: IpcResp::ShareMData(res),
+            req_id,
+        } => match res {
+            Ok(()) => o_share_mdata(user_data, req_id),
+            Err(err) => {
+                let e = Error::from(err);
+                let (error_code, description) = ffi_error!(e);
+                let res = NativeResult {
+                    error_code,
+                    description: Some(description),
+                }
+                .into_repr_c()?;
+                o_err(user_data, &res, req_id);
+            }
+        },
+        IpcMsg::Revoked { .. } => o_revoked(user_data),
+        _ => {
+            return Err(IpcError::InvalidMsg.into());
+        }
+    };
+
+    Ok(())
+}

--- a/safe-ffi/ffi/logging.rs
+++ b/safe-ffi/ffi/logging.rs
@@ -1,0 +1,138 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+use super::errors::{Error, Result};
+use ffi_utils::{catch_unwind_cb, FfiResult, ReprC, FFI_RESULT_OK};
+use safe_api::Error as NativeError;
+use safe_core::utils::logging;
+use std::ffi::CString;
+use std::os::raw::{c_char, c_void};
+
+/// This function should be called to enable logging to a file.
+/// If `output_file_name_override` is provided, then this path will be used for
+/// the log output file.
+#[no_mangle]
+pub unsafe extern "C" fn init_logging(
+    output_file_name_override: *const c_char,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
+) {
+    catch_unwind_cb(user_data, o_cb, || -> Result<()> {
+        if output_file_name_override.is_null() {
+            logging::init(false).map_err(|err| Error::from(NativeError::Unexpected(err)))?;
+        } else {
+            let output_file_name_override = String::clone_from_repr_c(output_file_name_override)?;
+            logging::init_with_output_file(false, output_file_name_override)
+                .map_err(|err| Error::from(NativeError::Unexpected(err)))?;
+        }
+        o_cb(user_data, FFI_RESULT_OK);
+        Ok(())
+    });
+}
+
+/// Returns the path at which the the configuration files are expected.
+#[no_mangle]
+pub unsafe extern "C" fn get_config_dir_path(
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, log_path: *const c_char),
+) {
+    catch_unwind_cb(user_data, o_cb, || -> Result<()> {
+        let config_dir = safe_core::config_dir()
+            .map_err(|err| Error::from(NativeError::Unexpected(err.to_string())))?;
+        let config_dir_path = CString::new(
+            config_dir
+                .into_os_string()
+                .into_string()
+                .map_err(|_| {
+                    Error::from(NativeError::Unexpected(
+                        "Couldn't convert OsString".to_string(),
+                    ))
+                })
+                .map_err(Error::from)?
+                .into_bytes(),
+        )?;
+        o_cb(user_data, FFI_RESULT_OK, config_dir_path.as_ptr());
+        Ok(())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ffi_utils::test_utils::{call_0, call_1};
+    use log::{debug, error};
+    use safe_core::config_dir;
+    use std::env;
+    use std::fs::{self, File};
+    use std::io::Read;
+    use std::path::PathBuf;
+    use std::str::FromStr;
+    use std::thread;
+    use std::time::Duration;
+    use unwrap::unwrap;
+
+    // Test path where log file is created.
+    #[test]
+    fn config_dir_path() {
+        let path: String = unsafe { unwrap!(call_1(|ud, cb| get_config_dir_path(ud, cb),)) };
+        let expected_path = unwrap!(unwrap!(config_dir()).into_os_string().into_string());
+
+        assert_eq!(path, expected_path);
+    }
+
+    // Test logging errors to file.
+    #[test]
+    fn file_logging() {
+        setup_log_config();
+
+        let log_file_name = unwrap!(PathBuf::from_str("AppClient.log"));
+
+        let file_name = unwrap!(CString::new(unwrap!(log_file_name
+            .clone()
+            .into_os_string()
+            .into_string())));
+        unsafe {
+            unwrap!(call_0(|ud, cb| init_logging(file_name.as_ptr(), ud, cb),));
+        }
+
+        let debug_msg = "This is a sample debug message".to_owned();
+        let junk_msg = "This message should not exist in the log file".to_owned();
+
+        error!("{}", debug_msg);
+        debug!("{}", junk_msg);
+
+        // Give some time to the async logging to flush in the background thread
+        thread::sleep(Duration::from_secs(1));
+
+        let log_path = unwrap!(config_dir()).join(log_file_name);
+        let mut log_file = unwrap!(File::open(log_path));
+        let mut file_content = String::new();
+
+        let written = unwrap!(log_file.read_to_string(&mut file_content));
+        assert!(written > 0);
+
+        assert!(file_content.contains(&debug_msg[..]));
+        assert!(!file_content.contains(&junk_msg[..]));
+    }
+
+    fn setup_log_config() {
+        let mut current_dir = unwrap!(env::current_dir());
+        let mut config_dir = unwrap!(config_dir());
+        unwrap!(fs::create_dir_all(config_dir.clone()));
+
+        if current_dir.as_path() != config_dir.as_path() {
+            // Try to copy log.toml from the current dir to config dir
+            // so that the config_handler can find it
+            current_dir.push("sample_log_file/log.toml");
+            config_dir.push("log.toml");
+
+            let _ = unwrap!(fs::copy(current_dir, config_dir));
+        }
+    }
+}

--- a/safe-ffi/ffi/logging.rs
+++ b/safe-ffi/ffi/logging.rs
@@ -18,7 +18,7 @@ use std::os::raw::{c_char, c_void};
 /// If `output_file_name_override` is provided, then this path will be used for
 /// the log output file.
 #[no_mangle]
-pub unsafe extern "C" fn init_logging(
+pub unsafe extern "C" fn app_init_logging(
     output_file_name_override: *const c_char,
     user_data: *mut c_void,
     o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
@@ -38,7 +38,7 @@ pub unsafe extern "C" fn init_logging(
 
 /// Returns the path at which the the configuration files are expected.
 #[no_mangle]
-pub unsafe extern "C" fn get_config_dir_path(
+pub unsafe extern "C" fn app_config_dir_path(
     user_data: *mut c_void,
     o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult, log_path: *const c_char),
 ) {
@@ -80,7 +80,7 @@ mod tests {
     // Test path where log file is created.
     #[test]
     fn config_dir_path() {
-        let path: String = unsafe { unwrap!(call_1(|ud, cb| get_config_dir_path(ud, cb),)) };
+        let path: String = unsafe { unwrap!(call_1(|ud, cb| app_config_dir_path(ud, cb),)) };
         let expected_path = unwrap!(unwrap!(config_dir()).into_os_string().into_string());
 
         assert_eq!(path, expected_path);
@@ -98,7 +98,11 @@ mod tests {
             .into_os_string()
             .into_string())));
         unsafe {
-            unwrap!(call_0(|ud, cb| init_logging(file_name.as_ptr(), ud, cb),));
+            unwrap!(call_0(|ud, cb| app_init_logging(
+                file_name.as_ptr(),
+                ud,
+                cb
+            ),));
         }
 
         let debug_msg = "This is a sample debug message".to_owned();

--- a/safe-ffi/ffi/mod.rs
+++ b/safe-ffi/ffi/mod.rs
@@ -17,6 +17,7 @@ pub mod ffi_structs;
 pub mod files;
 pub mod helpers;
 pub mod keys;
+pub mod logging;
 pub mod nrs;
 pub mod wallet;
 pub mod xorurl;

--- a/safe-ffi/ffi/mod.rs
+++ b/safe-ffi/ffi/mod.rs
@@ -16,6 +16,7 @@ pub mod fetch;
 pub mod ffi_structs;
 pub mod files;
 pub mod helpers;
+pub mod ipc;
 pub mod keys;
 pub mod logging;
 pub mod nrs;

--- a/safe-ffi/lib.rs
+++ b/safe-ffi/lib.rs
@@ -16,6 +16,7 @@ pub use ffi::fetch::*;
 pub use ffi::ffi_structs::*;
 pub use ffi::files::*;
 pub use ffi::helpers::*;
+pub use ffi::ipc::*;
 pub use ffi::keys::*;
 pub use ffi::logging::*;
 pub use ffi::nrs::*;

--- a/safe-ffi/lib.rs
+++ b/safe-ffi/lib.rs
@@ -17,6 +17,7 @@ pub use ffi::ffi_structs::*;
 pub use ffi::files::*;
 pub use ffi::helpers::*;
 pub use ffi::keys::*;
+pub use ffi::logging::*;
 pub use ffi::nrs::*;
 pub use ffi::wallet::*;
 pub use ffi::xorurl::*;

--- a/safe-ffi/sample_log_file/log.toml
+++ b/safe-ffi/sample_log_file/log.toml
@@ -1,0 +1,9 @@
+[appenders.async_file]
+kind = "async_file"
+output_file_name = "This-is-a-sample-output.log"
+file_timestamp = false
+append = false
+
+[root]
+level = "error"
+appenders = ["async_file"]


### PR DESCRIPTION
<!--
#### Thank you for contributing!

Please reference the issue(s) which this pull request addresses using [keywords](https://help.github.com/articles/closing-issues-using-keywords/) such as:

```
Resolves #452
Fixes #363
Closes #408
```

---

Provide QA team and reviewer steps to test the resolution.
For example:

```
QA:
Easiest way to test this PR would be to:
- Start authd
- login
- safe wallet insert <problem link>
- Expect to see an authentication error output

```

---

Commit messages should conform to the format:

```
<type>(<scope>): <description>

[optional body]

```

For example:

```
fix(auth): proper values returned on auth_decode_ipc_msg errors

  - Test case for authenticator error -208 IncompatibleMockStatus
  - Test case for authenticator error -103 when decoding share MData
    request for non-existent MData

```

Commit `type` can be one of:
**feat**: New feature
**fix**: Bug fix
**docs**: Documentation only changes
**style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
**refactor**: A code change that neither fixes a bug nor adds a feature
**perf**: A code change that improves performance
**test**: Adding missing tests
**chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation
**revert**: Reverting a feature, fix, or commit which introduces a regression or new bug

Commit `scope` is open to any succinct term which indicates the effected feature or component.

See [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)

---
Write your description below this line: -->
