### PR TITLE
feat/ffi: expose set_config_dir_path and app_is_mock API

### DIFF
--- a/safe-ffi/ffi/mod.rs
+++ b/safe-ffi/ffi/mod.rs
@@ -27,8 +27,9 @@ use errors::Result;
 use ffi_utils::{catch_unwind_cb, FfiResult, OpaqueCtx, ReprC, FFI_RESULT_OK};
 use helpers::from_c_str_to_str_option;
 use safe_api::Safe;
+use safe_core::config_handler;
 use std::{
-    ffi::CString,
+    ffi::{CString, OsStr},
     os::raw::{c_char, c_void},
 };
 
@@ -75,4 +76,37 @@ pub unsafe extern "C" fn connect_app(
         o_cb(user_data.0, FFI_RESULT_OK, Box::into_raw(Box::new(safe)));
         Ok(())
     })
+}
+
+/// Sets the path from which the `safe_core.config` file will be read.
+#[no_mangle]
+pub unsafe extern "C" fn app_set_config_dir_path(
+    new_path: *const c_char,
+    user_data: *mut c_void,
+    o_cb: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
+) {
+    catch_unwind_cb(user_data, o_cb, || -> Result<_> {
+        let new_path = String::clone_from_repr_c(new_path)?;
+        config_handler::set_config_dir_path(OsStr::new(&new_path));
+        o_cb(user_data, FFI_RESULT_OK);
+        Ok(())
+    });
+}
+
+#[no_mangle]
+pub extern "C" fn app_is_mock() -> bool {
+    cfg!(feature = "mock-network")
+}
+
+#[test]
+#[cfg(feature = "mock-network")]
+fn test_mock_build() {
+    assert_eq!(app_is_mock(), true);
+}
+
+// Test mock detection when not compiled against mock-routing.
+#[test]
+#[cfg(not(feature = "mock-network"))]
+fn test_not_mock_build() {
+    assert_eq!(app_is_mock(), false);
 }


### PR DESCRIPTION
<!--
#### Thank you for contributing!

Please reference the issue(s) which this pull request addresses using [keywords](https://help.github.com/articles/closing-issues-using-keywords/) such as:

```
Resolves #452
Fixes #363
Closes #408
```

---

Provide QA team and reviewer steps to test the resolution.
For example:

```
QA:
Easiest way to test this PR would be to:
- Start authd
- login
- safe wallet insert <problem link>
- Expect to see an authentication error output

```

---

Commit messages should conform to the format:

```
<type>(<scope>): <description>

[optional body]

```

For example:

```
fix(auth): proper values returned on auth_decode_ipc_msg errors

  - Test case for authenticator error -208 IncompatibleMockStatus
  - Test case for authenticator error -103 when decoding share MData
    request for non-existent MData

```

Commit `type` can be one of:
**feat**: New feature
**fix**: Bug fix
**docs**: Documentation only changes
**style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
**refactor**: A code change that neither fixes a bug nor adds a feature
**perf**: A code change that improves performance
**test**: Adding missing tests
**chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation
**revert**: Reverting a feature, fix, or commit which introduces a regression or new bug

Commit `scope` is open to any succinct term which indicates the effected feature or component.

See [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)

---
Write your description below this line: -->
