### PR TITLE
chore/template: remove specific rust version no from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- [ ] Using rust 1.35.0
+- [ ] Using [latest rust stable](https://www.rust-lang.org/)
 - [ ] Using an up-to-date master branch
 - [ ] Link to stacktrace in a Gist (for bugs)
 


### PR DESCRIPTION
mentioning a rust version number only leaves us with a maintenance overhead & confusion when it's out of date. Better to state that users should be using latest stable version, which we always aim to work with.
