### PR TITLE
feat/api: make the `inspect` API to return the complete URL resolution chain

### DIFF
--- a/safe-api/src/api/app/wallet.rs
+++ b/safe-api/src/api/app/wallet.rs
@@ -387,10 +387,11 @@ impl Safe {
 
     pub async fn wallet_get(&self, url: &str) -> Result<WalletSpendableBalances> {
         let (xorurl_encoder, _) = self.parse_and_resolve_url(url).await?;
-        self.wallet_fetch(&xorurl_encoder).await
+        self.fetch_wallet(&xorurl_encoder).await
     }
 
-    pub(crate) async fn wallet_fetch(
+    /// Fetch a Wallet from a XorUrlEncoder without performing any type of URL resolution
+    pub(crate) async fn fetch_wallet(
         &self,
         xorurl_encoder: &XorUrlEncoder,
     ) -> Result<WalletSpendableBalances> {
@@ -398,7 +399,7 @@ impl Safe {
             &self,
             xorurl_encoder.xorname(),
             xorurl_encoder.type_tag(),
-            &xorurl_encoder.to_string()?,
+            &xorurl_encoder.to_string(),
         )
         .await
     }

--- a/safe-api/src/api/app/wallet.rs
+++ b/safe-api/src/api/app/wallet.rs
@@ -387,11 +387,18 @@ impl Safe {
 
     pub async fn wallet_get(&self, url: &str) -> Result<WalletSpendableBalances> {
         let (xorurl_encoder, _) = self.parse_and_resolve_url(url).await?;
+        self.wallet_fetch(&xorurl_encoder).await
+    }
+
+    pub(crate) async fn wallet_fetch(
+        &self,
+        xorurl_encoder: &XorUrlEncoder,
+    ) -> Result<WalletSpendableBalances> {
         gen_wallet_spendable_balances_list(
             &self,
             xorurl_encoder.xorname(),
             xorurl_encoder.type_tag(),
-            url,
+            &xorurl_encoder.to_string()?,
         )
         .await
     }

--- a/safe-api/src/api/app/xorurl.rs
+++ b/safe-api/src/api/app/xorurl.rs
@@ -1396,11 +1396,19 @@ mod tests {
     }
 
     #[test]
-    fn test_xorurl_base32_encoding() -> Result<()> {
-        let xorname = XorName(*b"12345678901234567890123456789012");
-        let xorurl = XorUrlEncoder::encode_immutable_data(
-            xorname,
+    fn test_safeurl_base32_encoding() -> Result<()> {
+        let xor_name = XorName(*b"12345678901234567890123456789012");
+        let xorurl = SafeUrl::encode(
+            xor_name,
+            None,
+            0xa632_3c4d_4a32,
+            SafeDataType::PublishedImmutableData,
             SafeContentType::Raw,
+            None,
+            None,
+            None,
+            None,
+            None,
             XorUrlBase::Base32,
         )?;
         let base32_xorurl =

--- a/safe-api/src/api/app/xorurl.rs
+++ b/safe-api/src/api/app/xorurl.rs
@@ -1396,19 +1396,11 @@ mod tests {
     }
 
     #[test]
-    fn test_safeurl_base32_encoding() -> Result<()> {
-        let xor_name = XorName(*b"12345678901234567890123456789012");
-        let xorurl = SafeUrl::encode(
-            xor_name,
-            None,
-            0xa632_3c4d_4a32,
-            SafeDataType::PublishedImmutableData,
+    fn test_xorurl_base32_encoding() -> Result<()> {
+        let xorname = XorName(*b"12345678901234567890123456789012");
+        let xorurl = XorUrlEncoder::encode_immutable_data(
+            xorname,
             SafeContentType::Raw,
-            None,
-            None,
-            None,
-            None,
-            None,
             XorUrlBase::Base32,
         )?;
         let base32_xorurl =

--- a/safe-cli/subcommands/cat.rs
+++ b/safe-cli/subcommands/cat.rs
@@ -89,6 +89,9 @@ pub async fn cat_commander(
                 println!("{}", serialise_output(&(url, balances), output_fmt));
             }
         }
+        SafeData::NrsMapContainer { .. } => {
+            println!("No content to show since the URL targets a NrsMapContainer. Use the 'dog' command to obtain additional information about the targeted NrsMapContainer.");
+        }
         SafeData::SafeKey { .. } => {
             println!("No content to show since the URL targets a SafeKey. Use the 'dog' command to obtain additional information about the targeted SafeKey.");
         }

--- a/safe-cli/subcommands/cat.rs
+++ b/safe-cli/subcommands/cat.rs
@@ -8,7 +8,7 @@
 // Software.
 
 use super::{
-    helpers::{get_from_arg_or_stdin, serialise_output},
+    helpers::{get_from_arg_or_stdin, print_nrs_map, serialise_output},
     OutputFmt,
 };
 use log::debug;
@@ -89,8 +89,19 @@ pub async fn cat_commander(
                 println!("{}", serialise_output(&(url, balances), output_fmt));
             }
         }
-        SafeData::NrsMapContainer { .. } => {
-            println!("No content to show since the URL targets a NrsMapContainer. Use the 'dog' command to obtain additional information about the targeted NrsMapContainer.");
+        SafeData::NrsMapContainer {
+            public_name,
+            version,
+            nrs_map,
+            ..
+        } => {
+            // Render NRS Map Container
+            if OutputFmt::Pretty == output_fmt {
+                println!("NRS Map Container (version {}) at \"{}\":", version, url);
+                print_nrs_map(&nrs_map, public_name);
+            } else {
+                println!("{}", serialise_output(&(url, nrs_map), output_fmt));
+            }
         }
         SafeData::SafeKey { .. } => {
             println!("No content to show since the URL targets a SafeKey. Use the 'dog' command to obtain additional information about the targeted SafeKey.");

--- a/safe-cli/subcommands/dog.rs
+++ b/safe-cli/subcommands/dog.rs
@@ -13,7 +13,7 @@ use super::{
 };
 use log::debug;
 use prettytable::Table;
-use safe_api::{fetch::NrsMapContainerInfo, fetch::SafeData, Safe};
+use safe_api::{fetch::SafeData, Safe};
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
@@ -31,147 +31,40 @@ pub async fn dog_commander(
     debug!("Running dog for: {:?}", &url);
 
     let content = safe.inspect(&url).await?;
-    match &content {
-        SafeData::FilesContainer {
-            xorurl,
-            version,
-            type_tag,
-            xorname,
-            data_type,
-            resolved_from,
-            ..
-        } => {
-            if OutputFmt::Pretty == output_fmt {
-                println!("Native data type: {}", data_type);
+    for (i, ref c) in content.iter().enumerate() {
+        println!();
+        println!("== URL resolution step {} ==", i + 1);
+        match c {
+            SafeData::NrsMapContainer {
+                public_name,
+                xorurl,
+                xorname,
+                type_tag,
+                version,
+                nrs_map,
+                data_type,
+                resolved_from,
+            } => {
+                if resolved_from != xorurl {
+                    println!("Resolved from: {}", resolved_from);
+                }
+                println!("= NRS Map Container =");
+                println!("PublicName: \"{}\"", public_name);
+                println!("XOR-URL: {}", xorurl);
                 println!("Version: {}", version);
                 println!("Type tag: {}", type_tag);
                 println!("XOR name: 0x{}", xorname_to_hex(xorname));
-                println!("XOR-URL: {}", xorurl);
-                print_resolved_from(100, resolved_from);
-            } else if resolved_from.is_some() {
-                println!("{}", serialise_output(&(url, content), output_fmt));
-            } else {
-                let jsonv = serde_json::json!([
-                    url,
-                    {
-                        "data_type": data_type,
-                        "version": version,
-                        "type_tag": type_tag,
-                        "xorname": xorname_to_hex(xorname)
-                    }
-                ]);
-                println!("{}", serialise_output(&jsonv, output_fmt));
-            }
-        }
-        SafeData::PublishedImmutableData {
-            xorurl,
-            xorname,
-            resolved_from,
-            media_type,
-            ..
-        } => {
-            if OutputFmt::Pretty == output_fmt {
-                println!("Native data type: ImmutableData (published)");
-                println!("XOR name: 0x{}", xorname_to_hex(xorname));
-                println!("XOR-URL: {}", xorurl);
-                println!(
-                    "Media type: {}",
-                    media_type.clone().unwrap_or_else(|| "Unknown".to_string())
-                );
-                print_resolved_from(100, resolved_from);
-            } else if resolved_from.is_some() {
-                println!("{}", serialise_output(&(url, content), output_fmt));
-            } else {
-                let jsonv = serde_json::json!([
-                    url,
-                    {
-                        "data_type": "PublishedImmutableData",
-                        "media_type": media_type.clone().unwrap_or_else(|| "Unknown".to_string()),
-                        "xorname": xorname_to_hex(xorname)
-                    }
-                ]);
-                println!("{}", serialise_output(&jsonv, output_fmt));
-            }
-        }
-        SafeData::Wallet {
-            xorurl,
-            xorname,
-            type_tag,
-            data_type,
-            resolved_from,
-            ..
-        } => {
-            if OutputFmt::Pretty == output_fmt {
                 println!("Native data type: {}", data_type);
-                println!("Type tag: {}", type_tag);
-                println!("XOR name: 0x{}", xorname_to_hex(xorname));
-                println!("XOR-URL: {}", xorurl);
-                print_resolved_from(100, resolved_from);
-            } else if resolved_from.is_some() {
-                println!("{}", serialise_output(&(url, content), output_fmt));
-            } else {
-                let jsonv = serde_json::json!([
-                    url,
-                    {
-                        "data_type": data_type,
-                        "type_type": type_tag,
-                        "xorname": xorname_to_hex(xorname)
-                    }
-                ]);
-                println!("{}", serialise_output(&jsonv, output_fmt));
-            }
-        }
-        SafeData::SafeKey {
-            xorurl,
-            xorname,
-            resolved_from,
-        } => {
-            if OutputFmt::Pretty == output_fmt {
-                println!("Native data type: SafeKey");
-                println!("XOR name: 0x{}", xorname_to_hex(xorname));
-                println!("XOR-URL: {}", xorurl);
-                print_resolved_from(100, resolved_from);
-            } else if resolved_from.is_some() {
-                println!("{}", serialise_output(&(url, content), output_fmt));
-            } else {
-                let jsonv = serde_json::json!([
-                    url,
-                    {
-                        "data_type": "SafeKey",
-                        "xorname": xorname_to_hex(xorname)
-                    }
-                ]);
-                println!("{}", serialise_output(&jsonv, output_fmt));
-            }
-        }
-    }
 
-    Ok(())
-}
-
-pub fn print_resolved_from(info_level: u8, resolved_from: &Option<NrsMapContainerInfo>) {
-    if info_level > 1 {
-        if let Some(nrs_map_container) = resolved_from {
-            // print out the resolved_from info since it's --info level 2
-            println!();
-            println!("Resolved using NRS Map:");
-            println!("PublicName: \"{}\"", nrs_map_container.public_name);
-            println!("Container XOR-URL: {}", nrs_map_container.xorurl);
-            println!("Native data type: {}", nrs_map_container.data_type);
-            println!("Type tag: {}", nrs_map_container.type_tag);
-            println!("XOR name: 0x{}", xorname_to_hex(&nrs_map_container.xorname));
-            println!("Version: {}", nrs_map_container.version);
-
-            if info_level > 2 {
                 let mut table = Table::new();
                 table.add_row(
                     row![bFg->"NRS name/subname", bFg->"Created", bFg->"Modified", bFg->"Link"],
                 );
 
-                let summary = nrs_map_container.nrs_map.get_map_summary();
+                let summary = nrs_map.get_map_summary();
                 summary.iter().for_each(|(name, rdf_info)| {
                     table.add_row(row![
-                        format!("{}{}", name, nrs_map_container.public_name),
+                        format!("{}{}", name, public_name),
                         rdf_info["created"],
                         rdf_info["modified"],
                         rdf_info["link"],
@@ -179,6 +72,137 @@ pub fn print_resolved_from(info_level: u8, resolved_from: &Option<NrsMapContaine
                 });
                 table.printstd();
             }
+            SafeData::FilesContainer {
+                xorurl,
+                xorname,
+                type_tag,
+                version,
+                data_type,
+                resolved_from,
+                ..
+            } => {
+                if OutputFmt::Pretty == output_fmt {
+                    if resolved_from != xorurl {
+                        println!("Resolved from: {}", resolved_from);
+                    }
+                    println!("= FilesContainer =");
+                    println!("XOR-URL: {}", xorurl);
+                    println!("Version: {}", version);
+                    println!("Type tag: {}", type_tag);
+                    println!("XOR name: 0x{}", xorname_to_hex(xorname));
+                    println!("Native data type: {}", data_type);
+                // print_resolved_from(100, resolved_from);
+                //} else if resolved_from.is_some() {
+                //    println!("{}", serialise_output(&(url, content), output_fmt));
+                } else {
+                    let jsonv = serde_json::json!([
+                        url,
+                        {
+                            "data_type": data_type,
+                            "version": version,
+                            "type_tag": type_tag,
+                            "xorname": xorname_to_hex(xorname)
+                        }
+                    ]);
+                    println!("{}", serialise_output(&jsonv, output_fmt));
+                }
+            }
+            SafeData::PublishedImmutableData {
+                xorurl,
+                xorname,
+                media_type,
+                resolved_from,
+                ..
+            } => {
+                if OutputFmt::Pretty == output_fmt {
+                    if resolved_from != xorurl {
+                        println!("Resolved from: {}", resolved_from);
+                    }
+                    println!("= File =");
+                    println!("XOR-URL: {}", xorurl);
+                    println!("XOR name: 0x{}", xorname_to_hex(xorname));
+                    println!("Native data type: ImmutableData (published)");
+                    println!(
+                        "Media type: {}",
+                        media_type.clone().unwrap_or_else(|| "Unknown".to_string())
+                    );
+                // print_resolved_from(100, resolved_from);
+                //} else if resolved_from.is_some() {
+                //    println!("{}", serialise_output(&(url, content), output_fmt));
+                } else {
+                    let jsonv = serde_json::json!([
+                        url,
+                        {
+                            "data_type": "PublishedImmutableData",
+                            "media_type": media_type.clone().unwrap_or_else(|| "Unknown".to_string()),
+                            "xorname": xorname_to_hex(xorname)
+                        }
+                    ]);
+                    println!("{}", serialise_output(&jsonv, output_fmt));
+                }
+            }
+            SafeData::Wallet {
+                xorurl,
+                xorname,
+                type_tag,
+                data_type,
+                resolved_from,
+                ..
+            } => {
+                if OutputFmt::Pretty == output_fmt {
+                    if resolved_from != xorurl {
+                        println!("Resolved from: {}", resolved_from);
+                    }
+                    println!("= Wallet =");
+                    println!("XOR-URL: {}", xorurl);
+                    println!("Type tag: {}", type_tag);
+                    println!("XOR name: 0x{}", xorname_to_hex(xorname));
+                    println!("Native data type: {}", data_type);
+                // print_resolved_from(100, resolved_from);
+                //} else if resolved_from.is_some() {
+                //    println!("{}", serialise_output(&(url, content), output_fmt));
+                } else {
+                    let jsonv = serde_json::json!([
+                        url,
+                        {
+                            "data_type": data_type,
+                            "type_type": type_tag,
+                            "xorname": xorname_to_hex(xorname)
+                        }
+                    ]);
+                    println!("{}", serialise_output(&jsonv, output_fmt));
+                }
+            }
+            SafeData::SafeKey {
+                xorurl,
+                xorname,
+                resolved_from,
+            } => {
+                if OutputFmt::Pretty == output_fmt {
+                    if resolved_from != xorurl {
+                        println!("Resolved from: {}", resolved_from);
+                    }
+                    println!("= SafeKey =");
+                    println!("XOR-URL: {}", xorurl);
+                    println!("XOR name: 0x{}", xorname_to_hex(xorname));
+                    println!("Native data type: SafeKey");
+                // print_resolved_from(100, resolved_from);
+                //} else if resolved_from.is_some() {
+                //    println!("{}", serialise_output(&(url, content), output_fmt));
+                } else {
+                    let jsonv = serde_json::json!([
+                        url,
+                        {
+                            "data_type": "SafeKey",
+                            "xorname": xorname_to_hex(xorname)
+                        }
+                    ]);
+                    println!("{}", serialise_output(&jsonv, output_fmt));
+                }
+            }
         }
     }
+
+    println!();
+    Ok(())
 }

--- a/safe-cli/subcommands/helpers.rs
+++ b/safe-cli/subcommands/helpers.rs
@@ -12,7 +12,7 @@ use ansi_term::Style;
 use log::debug;
 use num_traits::Float;
 use prettytable::{format::FormatBuilder, Table};
-use safe_api::XorName;
+use safe_api::{nrs_map::NrsMap, XorName};
 use serde::ser::Serialize;
 use std::{
     collections::BTreeMap,
@@ -168,6 +168,23 @@ where
             "OutputFmt::Pretty' not handled by caller, in serialise_output()".to_string()
         }
     }
+}
+
+// Pretty print an NRS Map
+pub fn print_nrs_map(nrs_map: &NrsMap, public_name: &str) {
+    let mut table = Table::new();
+    table.add_row(row![bFg->"NRS name/subname", bFg->"Created", bFg->"Modified", bFg->"Link"]);
+
+    let summary = nrs_map.get_map_summary();
+    summary.iter().for_each(|(name, rdf_info)| {
+        table.add_row(row![
+            format!("{}{}", name, public_name),
+            rdf_info["created"],
+            rdf_info["modified"],
+            rdf_info["link"],
+        ]);
+    });
+    table.printstd();
 }
 
 // returns singular or plural version of string, based on count.

--- a/safe-cli/tests/cli_dog.rs
+++ b/safe-cli/tests/cli_dog.rs
@@ -12,7 +12,7 @@ extern crate safe_cmd_test_utilities;
 #[macro_use]
 extern crate duct;
 
-use safe_api::fetch::{SafeData, SafeDataType};
+use safe_api::fetch::SafeData;
 use safe_cmd_test_utilities::{
     create_preload_and_get_keys, get_random_nrs_string, parse_files_put_or_sync_output,
 };
@@ -48,23 +48,14 @@ fn calling_safe_dog_files_container_nrsurl() {
         .read()
         .unwrap();
 
-    let content_info: (String, SafeData) = serde_json::from_str(&dog_output)
-        .expect("Failed to parse output of `safe dog` with -ii on file");
-    assert_eq!(content_info.0, nrsurl);
-    if let SafeData::FilesContainer { resolved_from, .. } = content_info.1 {
-        let unwrapped_resolved_from = resolved_from.unwrap();
-        assert_eq!(
-            unwrapped_resolved_from.public_name,
-            nrsurl.replace("safe://", "")
-        );
-        assert_eq!(unwrapped_resolved_from.type_tag, 1500);
-        assert_eq!(unwrapped_resolved_from.version, 0);
-        assert_eq!(
-            unwrapped_resolved_from.data_type,
-            SafeDataType::PublishedSeqAppendOnlyData
-        );
+    let (url, mut content): (String, Vec<SafeData>) =
+        serde_json::from_str(&dog_output).expect("Failed to parse output of `safe dog` on file");
+    assert_eq!(url, nrsurl);
+
+    if let Some(SafeData::FilesContainer { resolved_from, .. }) = content.pop() {
+        assert_eq!(resolved_from, container_xorurl);
     } else {
-        panic!("Content retrieved was unexpected: {:?}", content_info);
+        panic!("Content retrieved was unexpected: {:?}", content);
     }
 }
 
@@ -102,23 +93,14 @@ fn calling_safe_dog_files_container_nrsurl_jsoncompact() {
     .read()
     .unwrap();
 
-    let content_info: (String, SafeData) =
+    let (url, mut content): (String, Vec<SafeData>) =
         serde_json::from_str(&dog_output).expect("Failed to parse output of `safe dog`");
-    assert_eq!(content_info.0, nrsurl);
-    if let SafeData::FilesContainer { resolved_from, .. } = content_info.1 {
-        let unwrapped_resolved_from = resolved_from.unwrap();
-        assert_eq!(
-            unwrapped_resolved_from.public_name,
-            nrsurl.replace("safe://", "")
-        );
-        assert_eq!(unwrapped_resolved_from.type_tag, 1500);
-        assert_eq!(unwrapped_resolved_from.version, 0);
-        assert_eq!(
-            unwrapped_resolved_from.data_type,
-            SafeDataType::PublishedSeqAppendOnlyData
-        );
+    assert_eq!(url, nrsurl);
+
+    if let Some(SafeData::FilesContainer { resolved_from, .. }) = content.pop() {
+        assert_eq!(resolved_from, container_xorurl);
     } else {
-        panic!("Content retrieved was unexpected: {:?}", content_info);
+        panic!("Content retrieved was unexpected: {:?}", content);
     }
 }
 
@@ -151,23 +133,14 @@ fn calling_safe_dog_files_container_nrsurl_yaml() {
         .read()
         .unwrap();
 
-    let content_info: (String, SafeData) =
+    let (url, mut content): (String, Vec<SafeData>) =
         serde_yaml::from_str(&dog_output).expect("Failed to parse output of `safe dog`");
-    assert_eq!(content_info.0, nrsurl);
-    if let SafeData::FilesContainer { resolved_from, .. } = content_info.1 {
-        let unwrapped_resolved_from = resolved_from.unwrap();
-        assert_eq!(
-            unwrapped_resolved_from.public_name,
-            nrsurl.replace("safe://", "")
-        );
-        assert_eq!(unwrapped_resolved_from.type_tag, 1500);
-        assert_eq!(unwrapped_resolved_from.version, 0);
-        assert_eq!(
-            unwrapped_resolved_from.data_type,
-            SafeDataType::PublishedSeqAppendOnlyData
-        );
+    assert_eq!(url, nrsurl);
+
+    if let Some(SafeData::FilesContainer { resolved_from, .. }) = content.pop() {
+        assert_eq!(resolved_from, container_xorurl);
     } else {
-        panic!("Content retrieved was unexpected: {:?}", content_info);
+        panic!("Content retrieved was unexpected: {:?}", content);
     }
 }
 
@@ -191,20 +164,13 @@ fn calling_safe_dog_safekey_nrsurl() {
         .read()
         .unwrap();
 
-    let content_info: (String, SafeData) = serde_json::from_str(&dog_output)
-        .expect("Failed to parse output of `safe dog` with -ii on file");
-    assert_eq!(content_info.0, nrsurl);
-    if let SafeData::SafeKey { resolved_from, .. } = content_info.1 {
-        let unwrapped_resolved_from = resolved_from.unwrap();
-        assert_eq!(
-            unwrapped_resolved_from.public_name,
-            nrsurl.replace("safe://", "")
-        );
-        assert_eq!(
-            unwrapped_resolved_from.data_type,
-            SafeDataType::PublishedSeqAppendOnlyData
-        );
+    let (url, mut content): (String, Vec<SafeData>) =
+        serde_json::from_str(&dog_output).expect("Failed to parse output of `safe dog` on file");
+    assert_eq!(url, nrsurl);
+
+    if let Some(SafeData::SafeKey { resolved_from, .. }) = content.pop() {
+        assert_eq!(resolved_from, safekey_xorurl);
     } else {
-        panic!("Content retrieved was unexpected: {:?}", content_info);
+        panic!("Content retrieved was unexpected: {:?}", content);
     }
 }

--- a/safe-cli/tests/cli_wallet.rs
+++ b/safe-cli/tests/cli_wallet.rs
@@ -432,7 +432,7 @@ fn calling_safe_wallet_create_w_bad_location() {
     ])
     .assert()
     .stderr(predicate::str::contains(
-        "The location couldn't be resolved from the NRS URL provided",
+        "Content not found at safe://nononooOOooo",
     ))
     .failure();
 }

--- a/safe-ffi/ffi/fetch.rs
+++ b/safe-ffi/ffi/fetch.rs
@@ -11,9 +11,8 @@ use super::{
     constants::{FILE_READ_FROM_START, FILE_READ_TO_END},
     errors::{Error, Result},
     ffi_structs::{
-        files_map_into_repr_c, nrs_map_container_info_into_repr_c,
-        wallet_spendable_balances_into_repr_c, FilesContainer, NrsMapContainerInfo,
-        PublishedImmutableData, SafeKey, Wallet,
+        files_map_into_repr_c, wallet_spendable_balances_into_repr_c, FilesContainer,
+        NrsMapContainer, PublishedImmutableData, SafeKey, Wallet,
     },
 };
 use ffi_utils::{catch_unwind_cb, vec_into_raw_parts, FfiResult, NativeResult, OpaqueCtx, ReprC};
@@ -32,6 +31,7 @@ pub unsafe extern "C" fn fetch(
     o_wallet: extern "C" fn(user_data: *mut c_void, data: *const Wallet),
     o_keys: extern "C" fn(user_data: *mut c_void, data: *const SafeKey),
     o_container: extern "C" fn(user_data: *mut c_void, data: *const FilesContainer),
+    o_nrs_map_container: extern "C" fn(user_data: *mut c_void, data: *const NrsMapContainer),
     o_err: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
 ) {
     catch_unwind_cb(user_data, o_err, || -> Result<()> {
@@ -55,6 +55,7 @@ pub unsafe extern "C" fn fetch(
             o_wallet,
             o_keys,
             o_container,
+            o_nrs_map_container,
             o_err,
         )
     })
@@ -69,11 +70,13 @@ pub unsafe extern "C" fn inspect(
     o_wallet: extern "C" fn(user_data: *mut c_void, data: *const Wallet),
     o_keys: extern "C" fn(user_data: *mut c_void, data: *const SafeKey),
     o_container: extern "C" fn(user_data: *mut c_void, data: *const FilesContainer),
+    o_nrs_map_container: extern "C" fn(user_data: *mut c_void, data: *const NrsMapContainer),
     o_err: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
 ) {
     catch_unwind_cb(user_data, o_err, || -> Result<()> {
         let url = String::clone_from_repr_c(url)?;
         let content = async_std::task::block_on((*app).inspect(&url));
+        // TODO: deal with vec<SafeData> type.
         invoke_callback(
             content,
             user_data,
@@ -81,6 +84,7 @@ pub unsafe extern "C" fn inspect(
             o_wallet,
             o_keys,
             o_container,
+            o_nrs_map_container,
             o_err,
         )
     })
@@ -93,6 +97,7 @@ unsafe fn invoke_callback(
     o_wallet: extern "C" fn(user_data: *mut c_void, data: *const Wallet),
     o_keys: extern "C" fn(user_data: *mut c_void, data: *const SafeKey),
     o_container: extern "C" fn(user_data: *mut c_void, data: *const FilesContainer),
+    o_nrs_map_container: extern "C" fn(user_data: *mut c_void, data: *const NrsMapContainer),
     o_err: extern "C" fn(user_data: *mut c_void, result: *const FfiResult),
 ) -> Result<()> {
     let user_data = OpaqueCtx(user_data);
@@ -101,8 +106,8 @@ unsafe fn invoke_callback(
             xorurl,
             data,
             xorname,
-            resolved_from,
             media_type,
+            resolved_from,
         }) => {
             let (data, data_len) = vec_into_raw_parts(data.to_vec());
             let published_data = PublishedImmutableData {
@@ -110,16 +115,8 @@ unsafe fn invoke_callback(
                 xorname: xorname.0,
                 data,
                 data_len,
-                resolved_from: match resolved_from {
-                    Some(nrs_container_map) => {
-                        nrs_map_container_info_into_repr_c(&nrs_container_map)?
-                    }
-                    None => NrsMapContainerInfo::new()?,
-                },
-                media_type: match media_type.clone() {
-                    Some(media) => CString::new(media)?.into_raw(),
-                    None => std::ptr::null(),
-                },
+                resolved_from: CString::new(resolved_from.clone())?.into_raw(),
+                media_type: CString::new(media_type.clone().unwrap())?.into_raw(),
             };
             o_published(user_data.0, &published_data);
         }
@@ -139,12 +136,7 @@ unsafe fn invoke_callback(
                 type_tag: *type_tag,
                 xorname: xorname.0,
                 data_type: (*data_type).clone() as u64,
-                resolved_from: match resolved_from {
-                    Some(nrs_container_map) => {
-                        nrs_map_container_info_into_repr_c(&nrs_container_map)?
-                    }
-                    None => NrsMapContainerInfo::new()?,
-                },
+                resolved_from: CString::new(resolved_from.clone())?.into_raw(),
             };
             o_container(user_data.0, &container);
         }
@@ -162,12 +154,7 @@ unsafe fn invoke_callback(
                 type_tag: *type_tag,
                 balances: wallet_spendable_balances_into_repr_c(balances)?,
                 data_type: (*data_type).clone() as u64,
-                resolved_from: match resolved_from {
-                    Some(nrs_container_map) => {
-                        nrs_map_container_info_into_repr_c(&nrs_container_map)?
-                    }
-                    None => NrsMapContainerInfo::new()?,
-                },
+                resolved_from: CString::new(resolved_from.clone())?.into_raw(),
             };
             o_wallet(user_data.0, &wallet);
         }
@@ -179,14 +166,32 @@ unsafe fn invoke_callback(
             let keys = SafeKey {
                 xorurl: CString::new(xorurl.clone())?.into_raw(),
                 xorname: xorname.0,
-                resolved_from: match resolved_from {
-                    Some(nrs_container_map) => {
-                        nrs_map_container_info_into_repr_c(&nrs_container_map)?
-                    }
-                    None => NrsMapContainerInfo::new()?,
-                },
+                resolved_from: CString::new(resolved_from.clone())?.into_raw(),
             };
             o_keys(user_data.0, &keys);
+        }
+        Ok(SafeData::NrsMapContainer {
+            public_name,
+            xorurl,
+            xorname,
+            type_tag,
+            version,
+            nrs_map,
+            data_type,
+            resolved_from,
+        }) => {
+            let nrs_map_json = serde_json::to_string(&nrs_map)?;
+            let nrs_map_container = NrsMapContainer {
+                public_name: CString::new(public_name.clone())?.into_raw(),
+                xorurl: CString::new(xorurl.clone())?.into_raw(),
+                xorname: xorname.0,
+                type_tag: *type_tag,
+                version: *version,
+                nrs_map: CString::new(nrs_map_json.clone())?.into_raw(),
+                data_type: (*data_type).clone() as u64,
+                resolved_from: CString::new(resolved_from.clone())?.into_raw(),
+            };
+            o_nrs_map_container(user_data.0, &nrs_map_container);
         }
         Err(err) => {
             let (error_code, description) = ffi_error!(Error::from(err.clone()));

--- a/safe-ffi/ffi/ffi_structs.rs
+++ b/safe-ffi/ffi/ffi_structs.rs
@@ -125,8 +125,8 @@ pub struct PublishedImmutableData {
     pub xorname: XorNameArray,
     pub data: *const u8,
     pub data_len: usize,
-    pub resolved_from: NrsMapContainerInfo,
     pub media_type: *const c_char,
+    pub resolved_from: NrsMapContainerInfo,
 }
 
 impl Drop for PublishedImmutableData {


### PR DESCRIPTION
Also, adapt the dog command to show every step in the resolution chain, and resolves #518 
Example `dog` command output with a long URL resolution chain:
```
$ safe dog safe://subfile

== URL resolution step 1 ==
= NRS Map Container =
PublicName: "subfile"
XOR-URL: safe://subfile
Version: 0
Type tag: 1500
XOR name: 0xaaebb5968b8eabdda8f9185cfca60198861b12a370b63bc5799edd7ce0bca2c3
Native data type: PublishedSeqAppendOnlyData
+------------------+----------------------+----------------------+------------------------------+
| NRS name/subname | Created              | Modified             | Link                         |
+------------------+----------------------+----------------------+------------------------------+
| subfile          | 2020-05-06T04:38:30Z | 2020-05-06T04:38:30Z | safe://subfolder/sub2.md?v=0 |
+------------------+----------------------+----------------------+------------------------------+

== URL resolution step 2 ==
Resolved from: safe://subfolder/sub2.md?v=0
= NRS Map Container =
PublicName: "subfolder"
XOR-URL: safe://subfolder?v=0
Version: 0
Type tag: 1500
XOR name: 0x505528ad158a19d4cd9360bcb644798100d30e432f206ddaff5607021477a986
Native data type: PublishedSeqAppendOnlyData
+------------------+----------------------+----------------------+-------------------------------+
| NRS name/subname | Created              | Modified             | Link                          |
+------------------+----------------------+----------------------+-------------------------------+
| subfolder        | 2020-05-06T04:38:08Z | 2020-05-06T04:38:08Z | safe://testdata/subfolder?v=0 |
+------------------+----------------------+----------------------+-------------------------------+

== URL resolution step 3 ==
Resolved from: safe://testdata/subfolder?v=0
= NRS Map Container =
PublicName: "testdata"
XOR-URL: safe://testdata?v=0
Version: 0
Type tag: 1500
XOR name: 0xebd25cfe070ab282250533a201e38c83249d489a3bf1c8f9718bad6369f59994
Native data type: PublishedSeqAppendOnlyData
+------------------+----------------------+----------------------+----------------------------+
| NRS name/subname | Created              | Modified             | Link                       |
+------------------+----------------------+----------------------+----------------------------+
| testdata         | 2020-05-06T04:37:50Z | 2020-05-06T04:37:50Z | safe://myname/testdata?v=0 |
+------------------+----------------------+----------------------+----------------------------+

== URL resolution step 4 ==
Resolved from: safe://myname/testdata?v=0
= NRS Map Container =
PublicName: "myname"
XOR-URL: safe://myname?v=0
Version: 0
Type tag: 1500
XOR name: 0x12a6bed73174ef3c2381b7361efb1974d94937da4691e79d2b7044a78d6e4ebe
Native data type: PublishedSeqAppendOnlyData
+------------------+----------------------+----------------------+--------------------------------------------------------------------------+
| NRS name/subname | Created              | Modified             | Link                                                                     |
+------------------+----------------------+----------------------+--------------------------------------------------------------------------+
| myname           | 2020-05-06T04:37:29Z | 2020-05-06T04:37:29Z | safe://hnyynyinqc81y36tknfpfdmztxbcd1s798fprdafzi4g4rj4hxioj1d14nbnc?v=0 |
+------------------+----------------------+----------------------+--------------------------------------------------------------------------+

== URL resolution step 5 ==
= FilesContainer =
XOR-URL: safe://hnyynyinqc81y36tknfpfdmztxbcd1s798fprdafzi4g4rj4hxioj1d14nbnc?v=0
Version: 0
Type tag: 1100
XOR name: 0x44e61e40cfa2a115a51aef17858395bbf395a41e0b7ae8da2275c7d60990e5a1
Native data type: PublishedSeqAppendOnlyData

== URL resolution step 6 ==
= File =
XOR-URL: safe://hbhynynt4oa3rihpop4sjppp3j5y59aa93a9ca7mqdkghg3mo9s76wgnis
XOR name: 0x4750c6495e360dd592d6b729d837fc63f9c7d98eadc351b86cae1fb77d430ab6
Native data type: ImmutableData (published)
Media type: text/markdown
``` 