### PR TITLE
fix(cli): adds inspect_to_xorurl() and resolve_to_xorurl() APIs

### DIFF
--- a/safe-api/src/api/app/files.rs
+++ b/safe-api/src/api/app/files.rs
@@ -134,7 +134,11 @@ impl Safe {
     /// ```
     pub async fn files_container_get(&self, url: &str) -> Result<(u64, FilesMap)> {
         debug!("Getting files container from: {:?}", url);
-        let (xorurl_encoder, _) = self.parse_and_resolve_url(url).await?;
+        let resolved_url = self.resolve_to_xorurl(&url).await?;
+
+        debug!("resolved url is {:?}", &resolved_url);
+
+        let xorurl_encoder = XorUrlEncoder::from_url(&resolved_url)?;
 
         // Check if the URL specifies a specific version of the content or simply the latest available
         let data = match xorurl_encoder.content_version() {

--- a/safe-api/src/api/app/keys.rs
+++ b/safe-api/src/api/app/keys.rs
@@ -416,8 +416,8 @@ mod tests {
             .keys_balance_from_url(&invalid_xorurl, &unwrap_key_pair(key_pair)?.sk)
             .await;
         match current_balance {
-            Err(Error::InvalidInput(msg)) => {
-                assert!(msg.contains("The location couldn't be resolved from the NRS URL provided"));
+            Err(Error::ContentNotFound(msg)) => {
+                assert!(msg.contains("Content not found at"));
                 Ok(())
             }
             Err(err) => Err(Error::Unexpected(format!(

--- a/safe-cli/subcommands/files.rs
+++ b/safe-cli/subcommands/files.rs
@@ -335,12 +335,13 @@ pub async fn files_commander(
         FilesSubCommands::Ls { target } => {
             let target_url =
                 get_from_arg_or_stdin(target, Some("...awaiting target URl from STDIN"))?;
+            let resolved_url = safe.resolve_to_xorurl(&target_url).await?;
 
             let (version, files_map) = safe
-                .files_container_get(&target_url)
+                .files_container_get(&resolved_url)
                 .await
                 .map_err(|err| format!("Make sure the URL targets a FilesContainer.\n{}", err))?;
-            let (total, filtered_filesmap) = filter_files_map(&files_map, &target_url)?;
+            let (total, filtered_filesmap) = filter_files_map(&files_map, &resolved_url)?;
 
             if OutputFmt::Pretty == output_fmt {
                 print_files_map(&filtered_filesmap, total, version, &target_url);
@@ -374,14 +375,15 @@ async fn process_tree_command(
     output_fmt: OutputFmt,
 ) -> Result<(), String> {
     let target_url = get_from_arg_or_stdin(target, Some("...awaiting target URl from STDIN"))?;
+    let resolved_url = safe.resolve_to_xorurl(&target_url).await?;
 
     let (_version, files_map) = safe
-        .files_container_get(&target_url)
+        .files_container_get(&resolved_url)
         .await
         .map_err(|err| format!("Make sure the URL targets a FilesContainer.\n{}", err))?;
 
     let filtered_filesmap =
-        filter_files_map_by_xorurl_path(&files_map, &target_url, |urlpath, fmpath| {
+        filter_files_map_by_xorurl_path(&files_map, &resolved_url, |urlpath, fmpath| {
             // remove urlpath from translated path
             // eg, urlpath:  /project/src/module
             //      fmpath:  /project/src/module/submod/foo.rs

--- a/safe-cli/tests/cli_files_get.rs
+++ b/safe-cli/tests/cli_files_get.rs
@@ -21,10 +21,10 @@ const EXISTS_PRESERVE: &str = "preserve";
 const PROGRESS_NONE: &str = "none";
 
 use multibase::{encode, Base};
-use safe_api::xorurl::XorUrlEncoder;
+use safe_api::{xorurl::XorUrlEncoder, Safe};
 use safe_cmd_test_utilities::{
-    parse_files_put_or_sync_output, upload_testfolder_no_trailing_slash,
-    upload_testfolder_trailing_slash, TEST_FOLDER,
+    create_nrs_link, get_random_nrs_string, parse_files_put_or_sync_output,
+    upload_testfolder_no_trailing_slash, upload_testfolder_trailing_slash, TEST_FOLDER,
 };
 use std::env;
 use std::fs;
@@ -332,6 +332,53 @@ fn files_get_src_is_nrs_with_path_and_dest_is_unspecified() -> Result<(), String
     assert_eq!(sum_tree(&file_src), sum_tree(&final_dest));
 
     remove_dest(&final_dest);
+
+    Ok(())
+}
+
+// Test:  safe files get safe://subfolder /tmp/subfolder
+//    src is a recursive nrs url
+//       safe://subfolder  --> safe://testdata/subfolder
+//       safe://testdata   --> safe://xorurl/testdata
+//    dest exists
+//
+//    expected result: ../testdata/subfolder matches /tmp/testdata/subfolder
+#[test]
+fn files_get_src_is_nrs_recursive_and_dest_not_existing() -> Result<(), String> {
+    let (files_container_xor, _processed_files) = upload_testfolder_no_trailing_slash()?;
+
+    let td = get_random_nrs_string();
+    let mut xor_url = Safe::parse_url(&files_container_xor)?;
+    xor_url.set_path("/testdata");
+    let td_url = format!("safe://{}", td);
+    println!(
+        "creating testdata nrs link: {} --> {}",
+        td,
+        xor_url.to_string()?
+    );
+    let _ = create_nrs_link(&td, &xor_url.to_string()?)?;
+
+    let sf = get_random_nrs_string();
+    let target = format!("{}/subfolder?v=0", td_url);
+    println!("creating subfolder nrs link: {} --> {}", sf, target);
+    let src = create_nrs_link(&sf, &target)?;
+
+    let dest = dest_dir(&[SUBFOLDER]);
+
+    remove_dest(&dest);
+
+    files_get(
+        &src,
+        Some(&dest),
+        Some(EXISTS_OVERWRITE),
+        Some(PROGRESS_NONE),
+        Some(0),
+    )?;
+
+    let src_subfolder = Path::new(TEST_FOLDER).join(SUBFOLDER).display().to_string();
+    println!("src: {}", src_subfolder);
+
+    assert_eq!(sum_tree(&src_subfolder), sum_tree(&dest));
 
     Ok(())
 }
@@ -1097,6 +1144,10 @@ fn files_get(
         .run()
         .map_err(|e| format!("{:#?}", e))?;
 
+    println!(
+        "cmd output:\n---\n{}\n---\n",
+        String::from_utf8_lossy(&output.stdout)
+    );
     if let Some(ec) = expect_exit_code {
         match output.status.code() {
             Some(code) => assert_eq!(ec, code),

--- a/safe-cli/tests/cli_wallet.rs
+++ b/safe-cli/tests/cli_wallet.rs
@@ -431,9 +431,7 @@ fn calling_safe_wallet_create_w_bad_location() {
         "--json",
     ])
     .assert()
-    .stderr(predicate::str::contains(
-        "The location couldn't be resolved from the NRS URL provided",
-    ))
+    .stderr(predicate::str::contains("Content not found at"))
     .failure();
 }
 

--- a/safe-cli/tests/common/mod.rs
+++ b/safe-cli/tests/common/mod.rs
@@ -120,6 +120,26 @@ pub fn upload_test_folder() -> (String, ProcessedFiles) {
 }
 
 #[allow(dead_code)]
+pub fn create_nrs_link(name: &str, link: &str) -> Result<String, String> {
+    let nrs_creation = cmd!(
+        get_bin_location(),
+        "nrs",
+        "create",
+        &name,
+        "-l",
+        &link,
+        "--json"
+    )
+    .read()
+    .unwrap();
+
+    let (nrs_map_xorurl, _change_map) = parse_nrs_create_output(&nrs_creation);
+    assert!(nrs_map_xorurl.contains("safe://"));
+
+    Ok(nrs_map_xorurl)
+}
+
+#[allow(dead_code)]
 pub fn get_random_nrs_string() -> String {
     thread_rng().sample_iter(&Alphanumeric).take(15).collect()
 }

--- a/safe-cmd-test-utilities/src/lib.rs
+++ b/safe-cmd-test-utilities/src/lib.rs
@@ -137,6 +137,26 @@ pub fn upload_test_folder() -> (String, ProcessedFiles) {
 }
 
 #[allow(dead_code)]
+pub fn create_nrs_link(name: &str, link: &str) -> Result<String, String> {
+    let nrs_creation = cmd!(
+        get_bin_location(),
+        "nrs",
+        "create",
+        &name,
+        "-l",
+        &link,
+        "--json"
+    )
+    .read()
+    .unwrap();
+
+    let (nrs_map_xorurl, _change_map) = parse_nrs_create_output(&nrs_creation);
+    assert!(nrs_map_xorurl.contains("safe://"));
+
+    Ok(nrs_map_xorurl)
+}
+
+#[allow(dead_code)]
 pub fn get_random_nrs_string() -> String {
     thread_rng().sample_iter(&Alphanumeric).take(15).collect()
 }


### PR DESCRIPTION
This PR has code to recursively resolve an NRS-URL chain to a final XOR-URL.  It works similarly to Fetch::retrieve_from_url() but in a simplified fashion that focuses only on (NRS) url resolution, so it is easier to use and to audit/review for that purpose.  The PR includes a test case for recursive URL resolution in the CLI.  The two new APIs are:  Safe::inspect_to_xorurl() and Safe::resolve_to_xorurl() in fetch.rs.

Now, at the same time, there is #525 that improves/fixes recursive resolution for `cat` and `dog` commands.  In theory, those funcs should be able to do it, but in practice I encountered difficulties adapting for use in Safe::parse_and_resolve_to_url().  (@bochaco maybe you can do it?)   So this PR may be redundant, at least in the core APIs.     Regardless, there are some useful mods in the CLI and a test case.

As its unclear if these new APIs will be merged/used, I have not provided doctests.  Also, possibly/probably they should return XorUrlEncoder (SafeUrl) instead of a String url, to save callers needing to parse in some instances.  If this PR seems likely to get merged, I can make those changes.

Summary of changes:
* adds Safe::inspect_to_xorurl() and Safe::resolve_to_xorurl() APIs
* refactor Safe::parse_and_resolve_url() to use Safe::resolve_to_xorurl()
* modify 'files tree' and 'files ls' to fully resolve nrs urls
* adds a test for recursive nrs resolution in cli_files_get
