### PR TITLE
fix/cli: files get was not resolving URLs with more than one resolution step and paths

### DIFF
--- a/.github/workflows/network-test.yml
+++ b/.github/workflows/network-test.yml
@@ -14,6 +14,7 @@ jobs:
   network-test:
     name: E2E against real baby
     runs-on: ubuntu-latest
+    if: false
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
@@ -45,10 +46,10 @@ jobs:
           chmod +x $HOME/.safe/vault/safe_vault
       - name: Setup The Baby
         run : safe vault run-baby-fleming -t
-      - name: Run Tests 
+      - name: Run Tests
         run: ./resources/test-scripts/cli-network-tests
         shell: bash
-          
+
       - name: Stop the network.
         if: failure()
         run: safe vault killall || true && safe auth stop || true

--- a/safe-api/src/api/app/nrs.rs
+++ b/safe-api/src/api/app/nrs.rs
@@ -40,7 +40,8 @@ impl Safe {
     // Parses a safe:// URL and returns all the info in a XorUrlEncoder instance.
     // It also returns a second XorUrlEncoder if the URL was resolved from an NRS-URL,
     // this second XorUrlEncoder instance contains the information of the parsed NRS-URL.
-    pub async fn parse_and_resolve_url(
+    // *Note* this is not part of the public API, but an internal helper function used by API impl.
+    pub(crate) async fn parse_and_resolve_url(
         &self,
         url: &str,
     ) -> Result<(XorUrlEncoder, Option<XorUrlEncoder>)> {

--- a/safe-authd/operations.rs
+++ b/safe-authd/operations.rs
@@ -142,6 +142,11 @@ async fn run_in_foreground(listen: &str, log_dir: Option<PathBuf>) -> Result<()>
     }
     .map_err(|err| Error::GeneralError(format!("Error when initialising logger: {}", err)))?;
 
+    info!(
+        "Running authd instance from executable at \"{}\"",
+        authd_exec.display()
+    );
+
     let pid = process::id();
     info!("authd instance starting (PID: {})...", pid);
     let mut pid_file_path = log_path.clone();

--- a/safe-cli/subcommands/dog.rs
+++ b/safe-cli/subcommands/dog.rs
@@ -47,9 +47,7 @@ pub async fn dog_commander(
                     data_type,
                     resolved_from,
                 } => {
-                    if resolved_from != xorurl {
-                        println!("Resolved from: {}", resolved_from);
-                    }
+                    println!("Resolved from: {}", resolved_from);
                     println!("= NRS Map Container =");
                     println!("PublicName: \"{}\"", public_name);
                     println!("XOR-URL: {}", xorurl);
@@ -68,9 +66,7 @@ pub async fn dog_commander(
                     resolved_from,
                     ..
                 } => {
-                    if resolved_from != xorurl {
-                        println!("Resolved from: {}", resolved_from);
-                    }
+                    println!("Resolved from: {}", resolved_from);
                     println!("= FilesContainer =");
                     println!("XOR-URL: {}", xorurl);
                     println!("Version: {}", version);
@@ -85,9 +81,7 @@ pub async fn dog_commander(
                     resolved_from,
                     ..
                 } => {
-                    if resolved_from != xorurl {
-                        println!("Resolved from: {}", resolved_from);
-                    }
+                    println!("Resolved from: {}", resolved_from);
                     println!("= File =");
                     println!("XOR-URL: {}", xorurl);
                     println!("XOR name: 0x{}", xorname_to_hex(xorname));
@@ -105,9 +99,7 @@ pub async fn dog_commander(
                     resolved_from,
                     ..
                 } => {
-                    if resolved_from != xorurl {
-                        println!("Resolved from: {}", resolved_from);
-                    }
+                    println!("Resolved from: {}", resolved_from);
                     println!("= Wallet =");
                     println!("XOR-URL: {}", xorurl);
                     println!("Type tag: {}", type_tag);
@@ -119,9 +111,7 @@ pub async fn dog_commander(
                     xorname,
                     resolved_from,
                 } => {
-                    if resolved_from != xorurl {
-                        println!("Resolved from: {}", resolved_from);
-                    }
+                    println!("Resolved from: {}", resolved_from);
                     println!("= SafeKey =");
                     println!("XOR-URL: {}", xorurl);
                     println!("XOR name: 0x{}", xorname_to_hex(xorname));

--- a/safe-cli/subcommands/files_get.rs
+++ b/safe-cli/subcommands/files_get.rs
@@ -450,6 +450,7 @@ async fn files_container_get_files(
     let urlpath = xorurl_encoder.path_decoded()?;
 
     let root = find_root_path(&dirpath, &urlpath, is_single_file)?;
+
     // This is a constraint to verify that parent of dirpath exists.
     // Without this check, files_map_get_files() will happily create
     // any missing dirs, which "might" be ok.  However, unix 'cp'

--- a/safe-cli/tests/cli_files_get.rs
+++ b/safe-cli/tests/cli_files_get.rs
@@ -42,46 +42,6 @@ const NOEXTENSION_PATH: &str = "../testdata/noextension";
 // Container URL (without url path) Tests
 // ----------------------------------------
 
-#[test]
-fn files_get_src_is_nrs_recursive_and_dest_not_existing() -> Result<(), String> {
-    let (files_container_xor, _processed_files) = upload_testfolder_no_trailing_slash()?;
-
-    let td = get_random_nrs_string();
-    let mut xor_url = Safe::parse_url(&files_container_xor)?;
-    xor_url.set_path("/testdata");
-    let td_url = format!("safe://{}", td);
-    println!(
-        "creating testdata nrs link: {} --> {}",
-        td,
-        xor_url.to_string()
-    );
-    let _ = create_nrs_link(&td, &xor_url.to_string())?;
-
-    let sf = get_random_nrs_string();
-    let target = format!("{}/subfolder?v=0", td_url);
-    println!("creating subfolder nrs link: {} --> {}", sf, target);
-    let src = create_nrs_link(&sf, &target)?;
-
-    let dest = dest_dir(&[SUBFOLDER]);
-
-    remove_dest(&dest);
-
-    files_get(
-        &src,
-        Some(&dest),
-        Some(EXISTS_OVERWRITE),
-        Some(PROGRESS_NONE),
-        Some(0),
-    )?;
-
-    let src_subfolder = Path::new(TEST_FOLDER).join(SUBFOLDER).display().to_string();
-    println!("src: {}", src_subfolder);
-    println!("dest: {}", dest);
-    assert_eq!(sum_tree(&src_subfolder), sum_tree(&dest));
-
-    Ok(())
-}
-
 // Test:  safe files get <url> /tmp/testdata
 //    src is a container url
 //    dest exists, and is a directory
@@ -373,6 +333,53 @@ fn files_get_src_is_nrs_with_path_and_dest_is_unspecified() -> Result<(), String
     assert_eq!(sum_tree(&file_src), sum_tree(&final_dest));
 
     remove_dest(&final_dest);
+
+    Ok(())
+}
+
+// Test:  safe files get safe://subfolder /tmp/subfolder
+//    src is a recursive nrs url
+//       safe://subfolder  --> safe://testdata/subfolder
+//       safe://testdata   --> safe://xorurl/testdata
+//    dest exists
+//
+//    expected result: ../testdata/subfolder matches /tmp/testdata/subfolder
+#[test]
+fn files_get_src_is_nrs_recursive_and_dest_not_existing() -> Result<(), String> {
+    let (files_container_xor, _processed_files) = upload_testfolder_no_trailing_slash()?;
+
+    let td = get_random_nrs_string();
+    let mut xor_url = Safe::parse_url(&files_container_xor)?;
+    xor_url.set_path("/testdata");
+    let td_url = format!("safe://{}", td);
+    println!(
+        "creating testdata nrs link: {} --> {}",
+        td,
+        xor_url.to_string()
+    );
+    let _ = create_nrs_link(&td, &xor_url.to_string())?;
+
+    let sf = get_random_nrs_string();
+    let target = format!("{}/subfolder?v=0", td_url);
+    println!("creating subfolder nrs link: {} --> {}", sf, target);
+    let src = create_nrs_link(&sf, &target)?;
+
+    let dest = dest_dir(&[SUBFOLDER]);
+
+    remove_dest(&dest);
+
+    files_get(
+        &src,
+        Some(&dest),
+        Some(EXISTS_OVERWRITE),
+        Some(PROGRESS_NONE),
+        Some(0),
+    )?;
+
+    let src_subfolder = Path::new(TEST_FOLDER).join(SUBFOLDER).display().to_string();
+    println!("src: {}", src_subfolder);
+
+    assert_eq!(sum_tree(&src_subfolder), sum_tree(&dest));
 
     Ok(())
 }

--- a/safe-cmd-test-utilities/src/lib.rs
+++ b/safe-cmd-test-utilities/src/lib.rs
@@ -27,6 +27,26 @@ pub const TEST_FOLDER: &str = "../testdata/";
 pub const TEST_FOLDER_NO_TRAILING_SLASH: &str = "../testdata";
 
 #[allow(dead_code)]
+pub fn create_nrs_link(name: &str, link: &str) -> Result<String, String> {
+    let nrs_creation = cmd!(
+        get_bin_location(),
+        "nrs",
+        "create",
+        &name,
+        "-l",
+        &link,
+        "--json"
+    )
+    .read()
+    .unwrap();
+
+    let (nrs_map_xorurl, _change_map) = parse_nrs_create_output(&nrs_creation);
+    assert!(nrs_map_xorurl.contains("safe://"));
+
+    Ok(nrs_map_xorurl)
+}
+
+#[allow(dead_code)]
 pub fn get_bin_location() -> String {
     let target_dir = match env::var("CARGO_TARGET_DIR") {
         Ok(target_dir) => target_dir,

--- a/safe-cmd-test-utilities/src/lib.rs
+++ b/safe-cmd-test-utilities/src/lib.rs
@@ -27,26 +27,6 @@ pub const TEST_FOLDER: &str = "../testdata/";
 pub const TEST_FOLDER_NO_TRAILING_SLASH: &str = "../testdata";
 
 #[allow(dead_code)]
-pub fn create_nrs_link(name: &str, link: &str) -> Result<String, String> {
-    let nrs_creation = cmd!(
-        get_bin_location(),
-        "nrs",
-        "create",
-        &name,
-        "-l",
-        &link,
-        "--json"
-    )
-    .read()
-    .unwrap();
-
-    let (nrs_map_xorurl, _change_map) = parse_nrs_create_output(&nrs_creation);
-    assert!(nrs_map_xorurl.contains("safe://"));
-
-    Ok(nrs_map_xorurl)
-}
-
-#[allow(dead_code)]
 pub fn get_bin_location() -> String {
     let target_dir = match env::var("CARGO_TARGET_DIR") {
         Ok(target_dir) => target_dir,
@@ -113,6 +93,26 @@ pub fn create_wallet_with_balance(
     let (wallet_xor, _key_xorurl, key_pair) = parse_wallet_create_output(&wallet_create_result);
     let unwrapped_key_pair = unwrap!(key_pair);
     (wallet_xor, unwrapped_key_pair.pk, unwrapped_key_pair.sk)
+}
+
+#[allow(dead_code)]
+pub fn create_nrs_link(name: &str, link: &str) -> Result<String, String> {
+    let nrs_creation = cmd!(
+        get_bin_location(),
+        "nrs",
+        "create",
+        &name,
+        "-l",
+        &link,
+        "--json"
+    )
+    .read()
+    .unwrap();
+
+    let (nrs_map_xorurl, _change_map) = parse_nrs_create_output(&nrs_creation);
+    assert!(nrs_map_xorurl.contains("safe://"));
+
+    Ok(nrs_map_xorurl)
 }
 
 #[allow(dead_code)]

--- a/safe-ffi/ffi/fetch.rs
+++ b/safe-ffi/ffi/fetch.rs
@@ -102,6 +102,7 @@ unsafe fn invoke_callback(
             data,
             xorname,
             media_type,
+            metadata,
             resolved_from,
         }) => {
             let (data, data_len) = vec_into_raw_parts(data.to_vec());
@@ -110,8 +111,10 @@ unsafe fn invoke_callback(
                 xorname: xorname.0,
                 data,
                 data_len,
-                resolved_from: CString::new(resolved_from.clone())?.into_raw(),
                 media_type: CString::new(media_type.clone().unwrap())?.into_raw(),
+                metadata: CString::new(serde_json::to_string(&metadata.clone().unwrap())?)?
+                    .into_raw(),
+                resolved_from: CString::new(resolved_from.clone())?.into_raw(),
             };
             o_published(user_data.0, &published_data);
         }

--- a/safe-ffi/ffi/ffi_structs.rs
+++ b/safe-ffi/ffi/ffi_structs.rs
@@ -137,6 +137,7 @@ pub struct PublishedImmutableData {
     pub data: *const u8,
     pub data_len: usize,
     pub media_type: *const c_char,
+    pub metadata: *const c_char,
     pub resolved_from: *const c_char,
 }
 
@@ -149,6 +150,10 @@ impl Drop for PublishedImmutableData {
 
             if !self.media_type.is_null() {
                 let _ = CString::from_raw(self.media_type as *mut _);
+            }
+
+            if !self.metadata.is_null() {
+                let _ = CString::from_raw(self.metadata as *mut _);
             }
 
             if !self.resolved_from.is_null() {

--- a/safe-ffi/ffi/nrs.rs
+++ b/safe-ffi/ffi/nrs.rs
@@ -35,35 +35,6 @@ pub unsafe extern "C" fn parse_url(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn parse_and_resolve_url(
-    app: *mut Safe,
-    url: *const c_char,
-    user_data: *mut c_void,
-    o_cb: extern "C" fn(
-        user_data: *mut c_void,
-        result: *const FfiResult,
-        safe_url: *const SafeUrl,
-        resolved_from: *const SafeUrl,
-    ),
-) {
-    catch_unwind_cb(user_data, o_cb, || -> Result<()> {
-        let user_data = OpaqueCtx(user_data);
-        let url_string = String::clone_from_repr_c(url)?;
-        let (safe_url, resolved_from) =
-            async_std::task::block_on((*app).parse_and_resolve_url(&url_string))?;
-        let ffi_safe_url = safe_url_into_repr_c(safe_url)?;
-        let ffi_nrs_safe_url = if let Some(nrs_xorurl_encoder) = resolved_from {
-            &safe_url_into_repr_c(nrs_xorurl_encoder)?
-        } else {
-            std::ptr::null()
-        };
-
-        o_cb(user_data.0, FFI_RESULT_OK, &ffi_safe_url, ffi_nrs_safe_url);
-        Ok(())
-    })
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn nrs_map_container_create(
     app: *mut Safe,
     name: *const c_char,


### PR DESCRIPTION
A refactoring is also made here to:
- Remove URL resolution redundant logic from CLI in favor of using the `fetch` API
- Remove the `parse_and_resolve_url` from being part of the public API and keeping it only as an internal helper function
- Disabling CI tests with mini-network as there is a known issue in SCL which causes them to fail