### PR TITLE
support empty directories and lays groundwork for symlinks and hidden files.

### DIFF
--- a/safe-api/src/api/app/consts.rs
+++ b/safe-api/src/api/app/consts.rs
@@ -22,3 +22,16 @@ pub const FAKE_RDF_PREDICATE_TYPE: &str = "type";
 pub const FAKE_RDF_PREDICATE_SIZE: &str = "size";
 pub const FAKE_RDF_PREDICATE_MODIFIED: &str = "modified";
 pub const FAKE_RDF_PREDICATE_CREATED: &str = "created";
+pub const FAKE_RDF_PREDICATE_ORIGINAL_MODIFIED: &str = "o_modified";
+pub const FAKE_RDF_PREDICATE_ORIGINAL_CREATED: &str = "o_created";
+pub const FAKE_RDF_PREDICATE_READONLY: &str = "readonly";
+pub const FAKE_RDF_PREDICATE_MODE_BITS: &str = "mode_bits";
+
+// see: https://stackoverflow.com/questions/18869772/mime-type-for-a-directory
+// We will use the FreeDesktop standard for directories and symlinks.
+//   https://specifications.freedesktop.org/shared-mime-info-spec/shared-mime-info-spec-latest.html#idm140625828597376
+//
+// TBD: is there a better location for these?
+//      maybe files.rs or xorurl_media_types.rs?
+pub const MIMETYPE_FILESYSTEM_DIR: &str = "inode/directory";
+pub const MIMETYPE_FILESYSTEM_SYMLINK: &str = "inode/symlink";

--- a/safe-api/src/api/app/helpers.rs
+++ b/safe-api/src/api/app/helpers.rs
@@ -9,10 +9,11 @@
 
 use super::common::{parse_hex, sk_from_hex};
 use crate::{Error, Result};
-use chrono::{SecondsFormat, Utc};
+use chrono::{DateTime, SecondsFormat, Utc};
 use safe_core::ipc::{decode_msg, resp::AuthGranted, BootstrapConfig, IpcMsg, IpcResp};
 use safe_nd::{Coins, Error as SafeNdError, PublicKey as SafeNdPublicKey, XorName};
 use std::str::{self, FromStr};
+use std::time;
 use threshold_crypto::{serde_impl::SerdeSecret, PublicKey, SecretKey, PK_SIZE};
 
 /// The conversion from coin to raw value
@@ -120,6 +121,11 @@ pub fn decode_ipc_msg(ipc_msg: &str) -> Result<AuthResponseType> {
         IpcMsg::Revoked { .. } => Err(Error::AuthError("Authorisation denied".to_string())),
         other => Err(Error::AuthError(format!("{:?}", other))),
     }
+}
+
+pub fn systemtime_to_rfc3339(t: &time::SystemTime) -> String {
+    let datetime: DateTime<Utc> = t.clone().into();
+    datetime.to_rfc3339_opts(SecondsFormat::Secs, true)
 }
 
 pub fn gen_timestamp_secs() -> String {

--- a/safe-cli/subcommands/cat.rs
+++ b/safe-cli/subcommands/cat.rs
@@ -47,15 +47,16 @@ pub async fn cat_commander(
                 );
                 let mut table = Table::new();
                 table.add_row(
-                    row![bFg->"Name", bFg->"Size", bFg->"Created", bFg->"Modified", bFg->"Link"],
+                    row![bFg->"Name", bFg->"Type", bFg->"Size", bFg->"Created", bFg->"Modified", bFg->"Link"],
                 );
                 files_map.iter().for_each(|(name, file_item)| {
                     table.add_row(row![
                         name,
+                        file_item["type"],
                         file_item["size"],
                         file_item["created"],
                         file_item["modified"],
-                        file_item["link"],
+                        file_item.get("link").unwrap_or(&String::default()),
                     ]);
                 });
                 table.printstd();

--- a/safe-cli/tests/cli_files_get.rs
+++ b/safe-cli/tests/cli_files_get.rs
@@ -1066,7 +1066,7 @@ fn not_hidden_or_empty(entry: &DirEntry, max_depth: usize) -> bool {
 
 // generates a sha3_256 digest/hash of a directory tree.
 //
-// Note: hidden files or empty directories are not included.
+// Note: hidden files or directories are not included.
 //  this is necessary for comparing ../testdata with
 //  dest dir since `safe files put` presently ignores hidden
 //  files.  The hidden files can be included once
@@ -1082,9 +1082,6 @@ fn sum_tree(path: &str) -> String {
 
     let mut digests = String::new();
     for p in paths {
-        if p.path().is_dir() && dir_is_empty(&p.path()) {
-            continue;
-        }
         let relpath = p.path().strip_prefix(path).unwrap().display().to_string();
         digests.push_str(&str_to_sha3_256(&relpath));
         if p.path().is_file() {
@@ -1092,23 +1089,6 @@ fn sum_tree(path: &str) -> String {
         }
     }
     str_to_sha3_256(&digests)
-}
-
-// checks if a directory is empty, ignoring hidden files.
-// ie, a dir containing only hidden files is considered empty.
-//
-// Note: this is necessary for comparing ../testdata with
-// dest dir since `safe files put` presently ignores hidden
-// files.  The hidden files can be included once
-// 'safe files put' is fixed to include them.
-fn dir_is_empty(path: &Path) -> bool {
-    let entries = path.read_dir().unwrap();
-    for e in entries {
-        if !e.unwrap().file_name().to_str().unwrap().starts_with('.') {
-            return false;
-        }
-    }
-    true
 }
 
 // returns sha3_256 digest/hash of a file as a string.
@@ -1138,6 +1118,8 @@ fn files_get(
     .filter(|a| !a.is_empty())
     .collect();
 
+    println!("Executing: safe {}", display_args(&args));
+
     let output = duct::cmd(env!("CARGO_BIN_EXE_safe"), &args)
         .stdout_capture()
         .stderr_capture()
@@ -1152,6 +1134,15 @@ fn files_get(
         }
     }
     Ok(output)
+}
+
+fn display_args(args: &[String]) -> String {
+    let mut buf = String::default();
+    for arg in args {
+        buf.push_str(arg);
+        buf.push(' ');
+    }
+    buf
 }
 
 // For dynamically generating cmd args.

--- a/safe-cli/tests/cli_xorurl.rs
+++ b/safe-cli/tests/cli_xorurl.rs
@@ -38,9 +38,9 @@ fn calling_safe_xorurl_recursive() {
     let mut cmd = Command::cargo_bin(CLI).unwrap();
     cmd.args(&vec!["xorurl", TEST_FOLDER, "--recursive"])
         .assert()
-        .stdout(predicate::str::contains("5 file/s processed"))
+        .stdout(predicate::str::contains("7 file/s processed"))
         .stdout(predicate::str::contains(SAFE_PROTOCOL).count(5))
-        .stdout(predicate::str::contains(TEST_FOLDER).count(5))
+        .stdout(predicate::str::contains(TEST_FOLDER).count(7))
         .success();
 }
 


### PR DESCRIPTION
This PR enables support for PUT/GET of empty directories.

Until now, each FileItem in a FilesMap has represented a file.  Directories did not exist as their own entity, but rather were computed from file paths.   This strategy fails for empty directories because there is no file inside the directory, thus the directory is not included in any FileItem path.

This PR changes the scheme such that a FileItem may be a File, Directory, or Symlink.  The type is identified by the pre-existing "type" metadata field, which holds mime types.  So now, inode/directory --> Dir,  inode/symlink --> Symlink, anything else --> File.  This means that directories now have metadata such as created, modified, just like files do.

Some additonal metadata fields are also added, if available on local platform, towards the goal of reliable archive/restore of arbitrary directories:

* o_created  --> original (local) file created/birth time.
* o_modified --> original (local) file modified time.
* mode_bits  --> unix mode permissions.
* readonly --> original (local) readonly flag

Presently the idea is that these are always added on PUT, if locally available.  On restore (GET), a flag would enable writing with these archived values or not.   However, a flag could be added for the PUT case as well, eg to use less space.

Subsequent PR(s) will implement symlink support, retrieval flag(s), etc.  But I wanted to get this reviewed/merged before going much further down this road.

CLI code was updated to understand this new structure, and display/retrieve accordingly.

Backwards compatibility with data created before this change:

The code has been lightly manually tested by generating fake_vault_data.json using master branch and running `safe files put --recursive testdata/`.  I then ran `files ls`, `files tree`, `files get`, `cat` and `dog` against it, without error.  However, there remains a possibility of incompatibilities.

notable changes:
* files_container_create() and files_container_sync() now add FileItem entries for
  directories and symlinks. (symlink code is incomplete, and inactive)
* 'files ls', 'files tree', and 'files get' are aware of the directory entries
  and act accordingly.  future improvements possible.
* added 'Type' column to 'safe cat', which shows the mime-type.
* use constants for test file count expectations, to make updates easier.
* added FileMeta struct, to simplify passing file metadata around.  pub(crate)
* include unix mode bits in FileItem if available on platform.
* set FileItem type property to Dir --> inode/directory, symlink --> inode/symlink
* Files have 'link' property in FileItem, dirs and symlinks do not.
* support 'files ls /path/to/file'. Previously no file was found.
* match 'files ls' path argument by path component intead of by character
* added test test_files_container_create_get_empty_folder
* added test calling_safe_cat_subfolders
* updated many tests to expect directory FileItem entries, including testdata/emptyfolder

<!--
#### Thank you for contributing!

Please reference the issue(s) which this pull request addresses using [keywords](https://help.github.com/articles/closing-issues-using-keywords/) such as:

```
Resolves #452
Fixes #363
Closes #408
```

---

Provide QA team and reviewer steps to test the resolution.
For example:

```
QA:
Easiest way to test this PR would be to:
- Start authd
- login
- safe wallet insert <problem link>
- Expect to see an authentication error output

```

---

Commit messages should conform to the format:

```
<type>(<scope>): <description>

[optional body]

```

For example:

```
fix(auth): proper values returned on auth_decode_ipc_msg errors

  - Test case for authenticator error -208 IncompatibleMockStatus
  - Test case for authenticator error -103 when decoding share MData
    request for non-existent MData

```

Commit `type` can be one of:
**feat**: New feature
**fix**: Bug fix
**docs**: Documentation only changes
**style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
**refactor**: A code change that neither fixes a bug nor adds a feature
**perf**: A code change that improves performance
**test**: Adding missing tests
**chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation
**revert**: Reverting a feature, fix, or commit which introduces a regression or new bug

Commit `scope` is open to any succinct term which indicates the effected feature or component.

See [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)

---
Write your description below this line: -->
