### PR TITLE
feat(cli): put/sync includes "hidden" files, and omit sub-dirs if not recursive.

### DIFF
--- a/safe-cli/tests/cli_xorurl.rs
+++ b/safe-cli/tests/cli_xorurl.rs
@@ -38,9 +38,9 @@ fn calling_safe_xorurl_recursive() {
     let mut cmd = Command::cargo_bin(CLI).unwrap();
     cmd.args(&vec!["xorurl", TEST_FOLDER, "--recursive"])
         .assert()
-        .stdout(predicate::str::contains("7 file/s processed"))
-        .stdout(predicate::str::contains(SAFE_PROTOCOL).count(5))
-        .stdout(predicate::str::contains(TEST_FOLDER).count(7))
+        .stdout(predicate::str::contains("11 file/s processed"))
+        .stdout(predicate::str::contains(SAFE_PROTOCOL).count(8))
+        .stdout(predicate::str::contains(TEST_FOLDER).count(11))
         .success();
 }
 


### PR DESCRIPTION
Changes in this PR:

1. removes the filter for files/dirs beginning with `.` when performing PUT or SYNC
2. omits sub-directories from PUT or SYNC if recursive flag not present.  (prevents empty sub-dirs)
3. updates tests to expect the above changes.

Rationale for 1:

* The check for files beginning with `.` is a platform specific (unix) method to identify hidden files and filter them out.  However, hidden files work differently on windows, so arguably this check wasn't even accomplishing its purpose on that platform, and possibly others.
* As far as I can see, there is no valid reason to filter hidden files in mandatory fashion.  It would definitely surprise users that are familiar with cp, scp, or rsync, as these tools do not do this.
* Decisions about this kind of filtering should be made by the individual app/dev, not by safe-api.
* If we decide to implement such an option to omit hidden files in end-user tool(s), such as safe-cli, then probably we should expose a filtering callback, or alternative mechanism for app to build FilesMap itself.  Anyway, that could be a separate PR.

Rationale for 2:
* Previously, a non-recursive PUT would include sub-dirs without their children. (empty)  That's somewhat weird, as it is kinda/sorta like recursion, but not.
* Act like familiar tools. `cp testdata/* /tmp/testdata/` omits child directories.  (it does emit a warning, perhaps API should log one)

Note that the `testdata/emptyfolder` directory is not actually empty because it contains a `.gitkeep` file.  Git doesn't actually support empty directories, so we can't keep a truly empty dir in a git repo.  Since `files put` is now including `testdata/emptyfolder/.gitkeep` in the FilesContainer, some tests that were depending on emptyfolder being empty broke.  To remedy this, I made a function in the tests to create a truly empty folder for each test as such: `<sys_tmp_dir>/<random_name>/emptyfolder`.  The `random_name` parent dir gets deleted after the test.


