### PR TITLE
fix(cli): addresses issue 510. 'files ls' now uses nrs paths

### DIFF
--- a/safe-api/src/api/app/fetch.rs
+++ b/safe-api/src/api/app/fetch.rs
@@ -19,6 +19,7 @@ pub use super::{
 use crate::{Error, Result};
 use log::{debug, info};
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 
 pub type Range = Option<(Option<u64>, Option<u64>)>;
 
@@ -264,7 +265,12 @@ async fn resolve_one_indirection(
                                 match file_item.get("link") {
                                     Some(link) => {
                                         let new_target_xorurl = XorUrlEncoder::from_url(link)?;
-                                        let metadata = (*file_item).clone();
+                                        let mut metadata = (*file_item).clone();
+                                        Path::new(&path).file_name().map(|name| {
+                                            name.to_str().map(|str| {
+                                                metadata.insert("name".to_string(), str.to_string())
+                                            })
+                                        });
                                         (files_map, Some((new_target_xorurl, Some(metadata))))
                                     }
                                     None => {

--- a/safe-cmd-test-utilities/src/lib.rs
+++ b/safe-cmd-test-utilities/src/lib.rs
@@ -198,10 +198,10 @@ pub fn parse_xorurl_output(output: &str) -> Vec<(String, String)> {
     serde_json::from_str(output).expect("Failed to parse output of `safe xorurl`")
 }
 
-// Executes arbitrary `safe ` commands and returns 
+// Executes arbitrary `safe ` commands and returns
 // output (stdout, stderr, exit code).
 //
-// If expect_exit_code is Some, then an Err is returned 
+// If expect_exit_code is Some, then an Err is returned
 // if value does not match process exit code.
 pub fn safe_cmd(args: &[&str], expect_exit_code: Option<i32>) -> Result<process::Output, String> {
     println!("Executing: safe {}", args.join(" "));


### PR DESCRIPTION
This PR contains a fix for #510, specifically for `files ls`, as `files tree` was already addressed.

Changes:
* `files ls` now uses Safe::inspect() api to resolve URLs.
* added optimization to filter_files_map() for single-file case, which can do a simple path lookup.
* added/moved/changed test cases:
    - calling_files_ls_on_nrs_with_path()
    - calling_files_ls_on_single_file
    - calling_files_ls_with_invalid_path()
* adds safe_cmd() to safe-cmd-test-utilities, a succinct way to exec, check exit code, and get all command output.



@bochaco please have a look at the changes in files.rs for `Ls` subcommand.  I had a lot of difficulty trying to get it to work for a single file path using the Safe::fetch() API, so I came up with an alternate solution using Safe::inspect().  I commented what it is doing carefully, to make the approach clear.  Anyway, I'm hoping you can come up with something cleaner, and/or modify the fetch() API somehow to deal with this type of case, eg maybe have an option to fetch until FileContainer found, and no further.