### PR TITLE
Add safe api code coverage and refactor GHA CI files

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    name: Build for becnhmarking
+    name: Build for benchmarking
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,20 +16,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release
-      - uses: actions/upload-artifact@master
+      - name: Build
+        run: cargo build --release
+      - name: Upload CLI
+        uses: actions/upload-artifact@master
         with:
           name: safe-cli
           path: target/release/safe
-      - uses: actions/upload-artifact@master
+      - name: Upload authd
+        uses: actions/upload-artifact@master
         with:
           name: safe-authd
           path: target/release/safe-authd
@@ -57,12 +58,14 @@ jobs:
           mkdir -p ~/.safe/authd
         
 
-      - uses: actions/download-artifact@master
+      - name: Download CLI
+        uses: actions/download-artifact@master
         with:
           name: safe-cli
           path: ./dl
     
-      - uses: actions/download-artifact@master
+      - name: Download authd
+        uses: actions/download-artifact@master
         with:
           name: safe-authd
           path: ./dl

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -37,11 +37,13 @@ jobs:
             output: safe-authd-x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
+
       # Cache.
       - name: Cache cargo registry
         uses: actions/cache@v1
@@ -60,11 +62,12 @@ jobs:
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
       # Build
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --manifest-path=${{ matrix.component }}/Cargo.toml
-      - uses: actions/upload-artifact@master
+      - name: Build
+        run: cargo build --release --manifest-path=${{ matrix.component }}/Cargo.toml
+
+      # Upload
+      - name: Upload
+        uses: actions/upload-artifact@master
         with:
           name: ${{ matrix.output }}
           path: target/release/${{ matrix.target }}
@@ -87,7 +90,8 @@ jobs:
             output: libsafe_ffi.dylib
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           profile: minimal
@@ -111,34 +115,35 @@ jobs:
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
       # Build prod FFI lib
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --manifest-path=${{ matrix.component }}/Cargo.toml
+      - name: Build FFI lib - Prod
+        run: cargo build --release --manifest-path=${{ matrix.component }}/Cargo.toml
+
       # Notarize FFI lib
       - name: Sign & Notarize
         shell: bash
         run: ./resources/notarize.sh ${{ matrix.output }}
         if: matrix.target == 'macOS-latest'
+
       # Upload prod FFI lib
-      - uses: actions/upload-artifact@master
+      - name: Upload prod FFI lib
+        uses: actions/upload-artifact@master
         with:
           name: ${{ matrix.component }}-${{ matrix.target }}-prod
           path: target/release/${{ matrix.output }}
+
       # Build dev FFI lib
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args:  >
-            --release --manifest-path=${{ matrix.component }}/Cargo.toml
-            --features=mock-network
+      - name: Build FFI lib - Dev
+        run: cargo build --release --manifest-path=${{ matrix.component }}/Cargo.toml --features=mock-network
+
       # Notarize FFI lib
       - name: Sign & Notarize
         shell: bash
         run: ./resources/notarize.sh ${{ matrix.output }}
         if: matrix.target == 'macOS-latest'
+
       # Upload dev FFI lib
-      - uses: actions/upload-artifact@master
+      - name: Upload dev FFI lib
+        uses: actions/upload-artifact@master
         with:
           name: ${{ matrix.component }}-${{ matrix.target }}-dev
           path: target/release/${{ matrix.output }}
@@ -167,11 +172,13 @@ jobs:
       CSC_IDENTITY_AUTO_DISCOVERY : true
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
+
       # Cache.
       - name: Cache cargo registry
         uses: actions/cache@v1
@@ -190,17 +197,22 @@ jobs:
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
       # Build
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --manifest-path=${{ matrix.component }}/Cargo.toml
+      - name: Build
+        run: cargo build --release --manifest-path=${{ matrix.component }}/Cargo.toml
+
+      # Sign & Notarize
       - name: Sign & Notarize
         shell: bash
         run: ./resources/notarize.sh ${{ matrix.target }}
+      
+      # List contents of release folder
       - name: what is in release...
         shell: bash
         run: ls target/release
-      - uses: actions/upload-artifact@master
+
+      # Upload
+      - name: Upload
+        uses: actions/upload-artifact@master
         with:
           name: ${{ matrix.output }}
           path: target/release/${{ matrix.target }}
@@ -214,7 +226,8 @@ jobs:
         component: [safe-ffi]
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           profile: minimal
@@ -273,27 +286,23 @@ jobs:
         run:  rustup target add ${{matrix.target}}
 
       # Build prod native lib.
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --manifest-path=${{ matrix.component }}/Cargo.toml --target=${{ matrix.target }}
+      - name: Build native lib - Prod
+        run: cargo build --release --manifest-path=${{ matrix.component }}/Cargo.toml --target=${{ matrix.target }}
 
       # Upload prod native lib.
-      - uses: actions/upload-artifact@master
+      - name: Upload prod native lib
+        uses: actions/upload-artifact@master
         with:
           name: safe-ffi-${{ matrix.target }}-prod
           path: target/${{ matrix.target }}/release/libsafe_ffi.so
 
       # Build dev native lib.
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --release --manifest-path=${{ matrix.component }}/Cargo.toml --target=${{ matrix.target }}
-            --features=mock-network
+      - name: Build native lib - Dev
+        run: cargo build --release --manifest-path=${{ matrix.component }}/Cargo.toml --target=${{ matrix.target }} --features=mock-network
 
       # Upload dev native lib.
-      - uses: actions/upload-artifact@master
+      - name: Upload dev native lib
+        uses: actions/upload-artifact@master
         with:
           name: safe-ffi-${{ matrix.target }}-dev
           path: target/${{ matrix.target }}/release/libsafe_ffi.so
@@ -306,13 +315,16 @@ jobs:
       DEVELOPER_DIR: /Applications/Xcode_11.2.app/Contents/Developer
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust aarch64-apple-ios target
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           profile: minimal
           override: true
           target: aarch64-apple-ios
-      - uses: actions-rs/toolchain@v1
+
+      - name: Install Rust x86_64-apple-ios target
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           profile: minimal
@@ -337,25 +349,29 @@ jobs:
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
      # Install cargo-lipo to generate universal libs.
-      - uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-lipo
+      - name: Install cargo-lipo
+        run: cargo install cargo-lipo
+
       # Build prod universal library.
       - name: Build universal lib - Prod
         shell: bash
         run: cargo lipo --release --manifest-path=safe-ffi/Cargo.toml
+
       # Upload prod universal library.
-      - uses: actions/upload-artifact@master
+      - name: Upload prod universal lib
+        uses: actions/upload-artifact@master
         with:
           name: safe-ffi-apple-ios-prod
           path: target/universal/release/libsafe_ffi.a
+
       # Build dev universal library.
       - name: Build universal lib - Dev
         shell: bash
         run: cargo lipo --release --manifest-path=safe-ffi/Cargo.toml --features=mock-network
+
       # Upload dev universal library.
-      - uses: actions/upload-artifact@master
+      - name: Upload dev universal lib
+        uses: actions/upload-artifact@master
         with:
           name: safe-ffi-apple-ios-dev
           path: target/universal/release/libsafe_ffi.a
@@ -377,79 +393,97 @@ jobs:
       # Checkout and get all the artifacts built in the previous jobs.
       - uses: actions/checkout@v1
       # cli
-      - uses: actions/download-artifact@master
+      - name: Download safe-x86_64-pc-windows-msvc release
+        uses: actions/download-artifact@master
         with:
           name: safe-x86_64-pc-windows-msvc
           path: artifacts/safe-cli/prod/x86_64-pc-windows-msvc/release
-      - uses: actions/download-artifact@master
+      - name: Download safe-x86_64-unknown-linux-gnu release
+        uses: actions/download-artifact@master
         with:
           name: safe-x86_64-unknown-linux-gnu
           path: artifacts/safe-cli/prod/x86_64-unknown-linux-gnu/release
-      - uses: actions/download-artifact@master
+      - name: Download safe-x86_64-apple-darwin release
+        uses: actions/download-artifact@master
         with:
           name: safe-x86_64-apple-darwin
           path: artifacts/safe-cli/prod/x86_64-apple-darwin/release
 
       # authd
-      - uses: actions/download-artifact@master
+      - name: Download safe-authd-x86_64-pc-windows-msvc release
+        uses: actions/download-artifact@master
         with:
           name: safe-authd-x86_64-pc-windows-msvc
           path: artifacts/safe-authd/prod/x86_64-pc-windows-msvc/release
-      - uses: actions/download-artifact@master
+      - name: Download safe-authd-x86_64-unknown-linux-gnu release
+        uses: actions/download-artifact@master
         with:
           name: safe-authd-x86_64-unknown-linux-gnu
           path: artifacts/safe-authd/prod/x86_64-unknown-linux-gnu/release
-      - uses: actions/download-artifact@master
+      - name: Download safe-authd-x86_64-apple-darwin release
+        uses: actions/download-artifact@master
         with:
           name: safe-authd-x86_64-apple-darwin
           path: artifacts/safe-authd/prod/x86_64-apple-darwin/release
 
       # ffi
-      - uses: actions/download-artifact@master
+      - name: Download safe-ffi-x86_64-pc-windows-msvc-prod release
+        uses: actions/download-artifact@master
         with:
           name: safe-ffi-x86_64-pc-windows-msvc-prod
           path: artifacts/safe-ffi/prod/x86_64-pc-windows-msvc/release
-      - uses: actions/download-artifact@master
+      - name: Download safe-ffi-x86_64-pc-windows-msvc-dev release
+        uses: actions/download-artifact@master
         with:
           name: safe-ffi-x86_64-pc-windows-msvc-dev
           path: artifacts/safe-ffi/dev/x86_64-pc-windows-msvc/release
-      - uses: actions/download-artifact@master
+      - name: Download safe-ffi-x86_64-unknown-linux-gnu-prod release
+        uses: actions/download-artifact@master
         with:
           name: safe-ffi-x86_64-unknown-linux-gnu-prod
           path: artifacts/safe-ffi/prod/x86_64-unknown-linux-gnu/release
-      - uses: actions/download-artifact@master
+      - name: Download safe-ffi-x86_64-unknown-linux-gnu-dev release
+        uses: actions/download-artifact@master
         with:
           name: safe-ffi-x86_64-unknown-linux-gnu-dev
           path: artifacts/safe-ffi/dev/x86_64-unknown-linux-gnu/release
-      - uses: actions/download-artifact@master
+      - name: Download safe-ffi-x86_64-apple-darwin-prod release
+        uses: actions/download-artifact@master
         with:
           name: safe-ffi-x86_64-apple-darwin-prod
           path: artifacts/safe-ffi/prod/x86_64-apple-darwin/release
-      - uses: actions/download-artifact@master
+      - name: Download safe-ffi-x86_64-apple-darwin-dev release
+        uses: actions/download-artifact@master
         with:
           name: safe-ffi-x86_64-apple-darwin-dev
           path: artifacts/safe-ffi/dev/x86_64-apple-darwin/release
-      - uses: actions/download-artifact@master
+      - name: Download safe-ffi-armv7-linux-androideabi-prod release
+        uses: actions/download-artifact@master
         with:
           name: safe-ffi-armv7-linux-androideabi-prod
           path: artifacts/safe-ffi/prod/armv7-linux-androideabi/release
-      - uses: actions/download-artifact@master
+      - name: Download safe-ffi-armv7-linux-androideabi-dev release
+        uses: actions/download-artifact@master
         with:
           name: safe-ffi-armv7-linux-androideabi-dev
           path: artifacts/safe-ffi/dev/armv7-linux-androideabi/release
-      - uses: actions/download-artifact@master
+      - name: Download safe-ffi-x86_64-linux-android-prod release
+        uses: actions/download-artifact@master
         with:
           name: safe-ffi-x86_64-linux-android-prod
           path: artifacts/safe-ffi/prod/x86_64-linux-android/release
-      - uses: actions/download-artifact@master
+      - name: Download safe-ffi-x86_64-linux-android-dev release
+        uses: actions/download-artifact@master
         with:
           name: safe-ffi-x86_64-linux-android-dev
           path: artifacts/safe-ffi/dev/x86_64-linux-android/release
-      - uses: actions/download-artifact@master
+      - name: Download safe-ffi-apple-ios-prod release
+        uses: actions/download-artifact@master
         with:
           name: safe-ffi-apple-ios-prod
           path: artifacts/safe-ffi/prod/apple-ios/release
-      - uses: actions/download-artifact@master
+      - name: Download safe-ffi-apple-ios-dev release
+        uses: actions/download-artifact@master
         with:
           name: safe-ffi-apple-ios-dev
           path: artifacts/safe-ffi/dev/apple-ios/release
@@ -585,7 +619,8 @@ jobs:
           echo "::set-output name=api_version::$api_version"
           echo "::set-output name=old_jsonrpc_version::$old_jsonrpc_version"
           echo "::set-output name=old_api_version::$old_api_version"
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable

--- a/.github/workflows/network-test.yml
+++ b/.github/workflows/network-test.yml
@@ -17,7 +17,8 @@ jobs:
     if: false
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
@@ -26,10 +27,8 @@ jobs:
       - name: dl vault
         run: wget https://github.com/maidsafe/safe_vault/releases/download/${{env.SAFE_VAULT_VERSION}}/safe_vault-${{env.SAFE_VAULT_VERSION}}-x86_64-unknown-linux-musl.zip
       - run: unzip safe_vault-${{env.SAFE_VAULT_VERSION}}-x86_64-unknown-linux-musl.zip -d $HOME/.safe/vault
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release
+      - name: Build
+        run: cargo build --release
       - name: Setup SAFE Cli and PATH etc
         run: |
           mkdir -p ~/.safe/safe-cli

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,6 +46,17 @@ jobs:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
+      # Run cargo tarpaulin & push result to coveralls.io
+      - name: Code Coverage - safe-api
+        uses: actions-rs/tarpaulin@master
+        with:
+          args: '-v --manifest-path=safe-api/Cargo.toml --features=scl-mock --exclude-files=safe-cli/*,jsonrpc-quic/*,safe-authd/*,safe-ffi/* --out Lcov -- --test-threads 1'
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./lcov.info
+
       # Run Clippy.
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,11 +12,12 @@ env:
 
 jobs:
   clippy:
-    name: Rustfmt-Clippy
+    name: Clippy, fmt & code coverage checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust and required components
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
@@ -24,10 +25,8 @@ jobs:
           components: rustfmt, clippy
 
       # Check if the code is formatted correctly.
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - name: Check formatting
+        run: cargo fmt --all -- --check
 
       # Cache.
       - name: Cache cargo registry
@@ -46,22 +45,22 @@ jobs:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
-      # Run cargo tarpaulin & push result to coveralls.io
+      # Run Clippy.
+      - name: Clippy checks
+        run: cargo clippy --all-targets --all-features
+
+      # Run cargo tarpaulin
       - name: Code Coverage - safe-api
         uses: actions-rs/tarpaulin@master
         with:
-          args: '-v --manifest-path=safe-api/Cargo.toml --features=scl-mock --exclude-files=safe-cli/*,jsonrpc-quic/*,safe-authd/*,safe-ffi/* --out Lcov -- --test-threads 1'
+          args: '-v --manifest-path=safe-api/Cargo.toml --features=scl-mock --exclude-files=safe-cli/*,jsonrpc-quic/*,safe-authd/*,safe-ffi/* --out Lcov -- --test-threads=1'
+      
+      # Push tarpaulin results to coveralls.io
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./lcov.info
-
-      # Run Clippy.
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --all-features
 
   build-ffi-android:
     name: Build FFI Android
@@ -72,7 +71,8 @@ jobs:
         component: [safe-ffi]
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           profile: minimal
@@ -131,27 +131,23 @@ jobs:
         run:  rustup target add ${{matrix.target}}
 
       # Build prod native lib.
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --manifest-path=${{ matrix.component }}/Cargo.toml --target=${{ matrix.target }}
+      - name: Build native lib - Prod
+        run: cargo build --release --manifest-path=${{ matrix.component }}/Cargo.toml --target=${{ matrix.target }}
 
       # Upload prod native lib.
-      - uses: actions/upload-artifact@master
+      - name: Upload prod native lib
+        uses: actions/upload-artifact@master
         with:
           name: safe-ffi-${{ matrix.target }}-prod
           path: target/${{ matrix.target }}/release/libsafe_ffi.so
 
       # Build dev native lib.
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: >
-            --release --manifest-path=${{ matrix.component }}/Cargo.toml --target=${{ matrix.target }}
-            --features=mock-network
+      - name: Build native lib - Dev
+        run: cargo build --release --manifest-path=${{ matrix.component }}/Cargo.toml --target=${{ matrix.target }} --features=mock-network
 
       # Upload dev native lib.
-      - uses: actions/upload-artifact@master
+      - name: Upload dev native lib 
+        uses: actions/upload-artifact@master
         with:
           name: safe-ffi-${{ matrix.target }}-dev
           path: target/${{ matrix.target }}/release/libsafe_ffi.so
@@ -164,13 +160,15 @@ jobs:
       DEVELOPER_DIR: /Applications/Xcode_11.2.app/Contents/Developer
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust target aarch64-apple-ios
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           profile: minimal
           override: true
           target: aarch64-apple-ios
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust target x86_64-apple-ios
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           profile: minimal
@@ -195,25 +193,29 @@ jobs:
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
       # Install cargo-lipo to generate universal libs.
-      - uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-lipo
+      - name: Install cargo-lipo
+        run: cargo install cargo-lipo
+
       # Build prod universal library.
       - name: Build universal lib - Prod
         shell: bash
         run: cargo lipo --release --manifest-path=safe-ffi/Cargo.toml
+
       # Upload prod universal library.
-      - uses: actions/upload-artifact@master
+      - name: Upload prod universal lib
+        uses: actions/upload-artifact@master
         with:
           name: safe-ffi-apple-ios-prod
           path: target/universal/release/libsafe_ffi.a
+
       # Build dev universal library.
       - name: Build universal lib - Dev
         shell: bash
         run: cargo lipo --release --manifest-path=safe-ffi/Cargo.toml --features=mock-network
+
       # Upload dev universal library.
-      - uses: actions/upload-artifact@master
+      - name: Upload dev universal lib
+        uses: actions/upload-artifact@master
         with:
           name: safe-ffi-apple-ios-dev
           path: target/universal/release/libsafe_ffi.a
@@ -227,11 +229,13 @@ jobs:
         component: [api-tests, cli-mock-tests, e2e-authd-mock-tests, e2e-authd-vault-tests]
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
+
       # Cache.
       - name: Cache cargo registry
         uses: actions/cache@v1


### PR DESCRIPTION
Code coverage is gathered through the cargo tarpaulin GHA and pushed to coveralls.io via the coveralls GHA.

Note that at this time the code coverage is only for the safe-api crate with `--features=scl-mock`, it excludes the other crates and features at this time. I have been investigating uploading an aggregated code coverage figure for safe-api and safe-cli, with multiple features, but I've hit multiple obstacles along the way so will need to return to that later.

Example on my fork of the code coverage stats being generated by CI successfully from this PR branch can be seen [here](https://github.com/S-Coyle/safe-api/runs/734970689?check_suite_focus=true). This has then been uploaded to my coveralls.io page [here](https://coveralls.io/github/S-Coyle/safe-api).

Also added a refactor commit to this PR - just some things I noticed while I was in there that I thought would improve the clarity & readability of both the GHA output and the CI file. I did this for the pr.yml and thought I may as well be consistent & do the same for the other CI files.
There are no functionality changes in the refactor commit.
Majority of the changes fall into one of these two categories:
1. add/clarify names for each process, to help clarify where failures occur, etc
2. remove the use of the `cargo` GitHub action - I don't think this gets us anything extra over just using `cargo` itself, we just end up with an unnecessary dependency & potential failure point. I've updated all occurrences to just use the `cargo` cmd instead of the action.