### PR TITLE
fix/cli: show the XOR-URL of an NRS Container (as part of dog cmd output) without any subname

### DIFF
--- a/safe-api/src/api/app/fetch.rs
+++ b/safe-api/src/api/app/fetch.rs
@@ -293,8 +293,7 @@ async fn resolve_one_indirection(
                 (files_map, None)
             };
 
-            // We don't want the path in the SafeData field,
-            // just the FilesContainer XOR-URL and version
+            // We don't want the path just the FilesContainer XOR-URL and version
             the_xor.set_path("");
             let safe_data = SafeData::FilesContainer {
                 xorurl: the_xor.to_xorurl_string(),
@@ -343,7 +342,9 @@ async fn resolve_one_indirection(
                 target_xorurl_encoder
             );
 
-            the_xor.set_path(""); // we don't want the path, just the NRS Map xorurl and version
+            // We don't want the path or subnames, just the FilesContainer XOR-URL and version
+            the_xor.set_path("");
+            the_xor.set_sub_names("")?;
             let nrs_map_container = SafeData::NrsMapContainer {
                 public_name: the_xor.top_name().to_string(),
                 xorurl: the_xor.to_xorurl_string(),
@@ -574,7 +575,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_fetch_resolvable_container() -> Result<()> {
-        let site_name: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
+        let random_str: String = thread_rng().sample_iter(&Alphanumeric).take(15).collect();
+        let site_name = format!("subname.{}", random_str);
 
         let mut safe = new_safe_instance().await?;
 
@@ -591,6 +593,9 @@ mod tests {
         let nrs_url = format!("safe://{}", site_name);
         let content = safe.fetch(&nrs_url, None).await?;
 
+        xorurl_encoder.set_sub_names("")?;
+        let xorurl_without_subname = xorurl_encoder.to_string();
+
         // this should resolve to a FilesContainer until we enable prevent resolution.
         match &content {
             SafeData::FilesContainer {
@@ -602,7 +607,7 @@ mod tests {
                 data_type,
                 ..
             } => {
-                assert_eq!(*xorurl, xorurl_encoder.to_string());
+                assert_eq!(*xorurl, xorurl_without_subname);
                 assert_eq!(*xorname, xorurl_encoder.xorname());
                 assert_eq!(*type_tag, 1_100);
                 assert_eq!(*version, 0);

--- a/safe-api/src/api/app/xorurl.rs
+++ b/safe-api/src/api/app/xorurl.rs
@@ -18,7 +18,6 @@ use multibase::{decode, encode, Base};
 use safe_nd::{XorName, XOR_NAME_LEN};
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::iter::FromIterator;
 use tiny_keccak::sha3_256;
 use url::Url;
 
@@ -225,7 +224,7 @@ impl SafeUrlParts {
         }
 
         // parse top_name and sub_names from name
-        let names_vec = Vec::from_iter(public_name.split('.').map(String::from));
+        let names_vec: Vec<String> = public_name.split('.').map(String::from).collect();
         let top_name = names_vec[names_vec.len() - 1].to_string();
         let sub_names_vec = (&names_vec[0..names_vec.len() - 1]).to_vec();
         let sub_names = sub_names_vec.join(".");
@@ -693,6 +692,16 @@ impl SafeUrl {
     /// eg: a.b.name --> &["a", "b"]
     pub fn sub_names_vec(&self) -> &[String] {
         &self.sub_names_vec
+    }
+
+    /// sets sub_names portion of URL
+    pub fn set_sub_names(&mut self, sub_names: &str) -> Result<()> {
+        let tmpurl = format!("{}{}.{}", SAFE_URL_PROTOCOL, sub_names, self.top_name());
+        let parts = SafeUrlParts::parse(&tmpurl)?;
+        self.sub_names = parts.sub_names;
+        self.sub_names_vec = parts.sub_names_vec;
+        self.public_name = parts.public_name;
+        Ok(())
     }
 
     /// returns XorUrl type tag
@@ -1722,6 +1731,20 @@ mod tests {
         let result = x.set_query_key(URL_VERSION_QUERY_NAME, Some("non-integer"));
         assert!(result.is_err());
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_safeurl_set_sub_names() -> Result<()> {
+        let mut x = SafeUrl::from_url("safe://sub1.sub2.myname?v=5")?;
+        assert_eq!(x.sub_names(), "sub1.sub2");
+        assert_eq!(x.sub_names_vec(), ["sub1", "sub2"]);
+
+        x.set_sub_names("s1.s2.s3")?;
+        assert_eq!(x.sub_names(), "s1.s2.s3");
+        assert_eq!(x.sub_names_vec(), ["s1", "s2", "s3"]);
+
+        assert_eq!(x.to_string(), "safe://s1.s2.s3.myname?v=5");
         Ok(())
     }
 


### PR DESCRIPTION
It resolves the issue reported on the SAFE forum: https://safenetforum.org/t/xor-url-from-dog-xor/31885