### PR TITLE
Version change: safe-cli-v0.15.0; safe-api-v0.15.0; safe-ffi-v0.15.0;…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,30 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### 0.13.1 (2020-06-11)
+### 0.15.0 (2020-07-16)
+
+### Features
+
+* ***api*** implements support for storing, retrieving and resolving symlinks ([01c62df](https://github.com/maidsafe/safe-api/commit/01c62dfc1f8d55ad005a67de0aff14eb54516369))
+
+* ***api & cli*** first draft implementation of a Sequence API and CLI commands ([e287d28](https://github.com/maidsafe/safe-api/commit/e287d2838e8a0c11c700b342989afa6e4b829cd3))
+
+* ***api*** migrate public FilesContainers and NRSContainers to use PublicSequence as its native data type ([3d00203](https://github.com/maidsafe/safe-api/commit/3d00203bd4fe073efed8f3f8921f2dd85c98954f)
+
+* ***api & cli*** allow to store, append and retrieve Private Sequence with API and CLI ([9c1a80b](https://github.com/maidsafe/safe-api/commit/9c1a80b1eb57948e08f5c548f318b4cbc36ea365))
+
+* ***cli*** show the native data XOR-URL in the dog output ([9abbecb](https://github.com/maidsafe/safe-api/commit/9abbecb5a909d3e38e471bd758ec6dd1a648151b))
+
+* ***ffi*** expose sequence data APIs from the ffi ([dfc3ca7](https://github.com/maidsafe/safe-api/commit/dfc3ca7aedd892d1497d4c9cc355ad7e08f8e572))
+
+### Bug Fixes
+
+* ***cli*** XOR-URL of a resolved NRS Container was displaying subnames as part of the output of the dog cmd ([bb9b15c](https://github.com/maidsafe/safe-api/commit/bb9b15cbd252ebd23b34253317535315d3d81f74))
+
+* ***api*** return an error when resolving a URL which contains subnames but targetting content non supporting subnames ([f1a9c60](https://github.com/maidsafe/safe-api/commit/f1a9c600ff05fca1481f13fe51358afe18819d01))
+
+
+### 0.14.0 (2020-06-11)
 
 ### Features
 

--- a/jsonrpc-quic/Cargo.toml
+++ b/jsonrpc-quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpc-quic"
-version = "0.0.7"
+version = "0.0.8"
 description = "JSON-RPC over QUIC for safe-authd comm"
 authors = ["bochaco <gabrielviganotti@gmail.com>"]
 license = "MIT OR BSD-3-Clause"

--- a/safe-api/Cargo.toml
+++ b/safe-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe-api"
-version = "0.14.0"
+version = "0.15.0"
 description = "SAFE API"
 authors = ["bochaco <gabrielviganotti@gmail.com>", "Josh Wilson <joshuef@gmail.com>"]
 license = "MIT OR BSD-3-Clause"
@@ -24,10 +24,10 @@ multibase = "~0.6.0"
 rand = "~0.6.5"
 rand_core = "~0.4.0"
 relative-path = "~0.4.0"
-safe_app = { git = "https://github.com/maidsafe/safe_client_libs", branch = "master" }
-safe_authenticator = { git = "https://github.com/maidsafe/safe_client_libs", branch = "master" }
-safe_core = { git = "https://github.com/maidsafe/safe_client_libs", branch = "master" }
-safe-nd = "~0.10.0"
+safe_app = "~0.17.1"
+safe_authenticator = "~0.17.1"
+safe_core = "~0.42.1"
+safe-nd = "~0.10.1"
 serde = "1.0.91"
 serde_json = "1.0.41"
 threshold_crypto = "~0.3.2"

--- a/safe-authd/Cargo.toml
+++ b/safe-authd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe-authd"
-version = "0.0.10"
+version = "0.0.11"
 description = "SAFE Authenticator (daemon)"
 authors = ["bochaco <gabrielviganotti@gmail.com>"]
 publish = false

--- a/safe-cli/Cargo.toml
+++ b/safe-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe-cli"
-version = "0.14.0"
+version = "0.15.0"
 description = "SAFE CLI"
 authors = ["bochaco <gabrielviganotti@gmail.com>", "Josh Wilson <joshuef@gmail.com>"]
 publish = false
@@ -59,7 +59,7 @@ assert_cmd = "~0.11.1"
 duct = "~0.12.0"
 predicates = "1.0.0"
 pretty_assertions = "~0.6.1"
-safe-nd = "~0.10.0"
+safe-nd = "~0.10.1"
 unwrap = "1.2.1"
 criterion = "~0.3"
 walkdir = "2.3.1"

--- a/safe-ffi/Cargo.toml
+++ b/safe-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe-ffi"
-version = "0.14.0"
+version = "0.15.0"
 description = "SAFE API FFI"
 authors = ["Ravinder Jangra <ravinderjangra@live.com>"]
 publish = false
@@ -16,15 +16,15 @@ path = "lib.rs"
 
 [dependencies]
 async-std = "1.6.0"
-ffi_utils = "~0.16.0"
+ffi_utils = "~0.17.0"
 # Required by ffi_utils macros.
 log = "~0.4.8"
-safe-nd = "~0.10.0"
+safe-nd = "~0.10.1"
 serde = "1.0.91"
 serde_json = "1.0.39"
-safe_core = { git = "https://github.com/maidsafe/safe_client_libs", branch = "master" }
+safe_core = "~0.42.1"
 bincode = "1.1.4"
-safe_authenticator_ffi = { git = "https://github.com/maidsafe/safe_client_libs", branch = "master" }
+safe_authenticator_ffi = "~0.17.1"
 
 [dependencies.safe-api]
 path = "../safe-api"
@@ -36,7 +36,7 @@ unwrap = "1.2.1"
 
 [build-dependencies]
 safe_bindgen = { git = "https://github.com/maidsafe/safe_bindgen", optional = true }
-safe-nd = "~0.10.0"
+safe-nd = "~0.10.1"
 unwrap = "1.2.1"
 
 [features]


### PR DESCRIPTION
… safe-authd-v0.0.11; jsonrpc-quic-v0.0.8

NOTE - Not sure what the CI issue with coveralls is, but it can be ignored for this PR, and that whole section of CI is reformatted in #592 