### PR TITLE
On version change upload `latest` zips and tars to S3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ package-version-artifacts-for-deploy:
 	mkdir -p deploy/prod
 	mkdir -p deploy/dev
 	./resources/package-deploy-artifacts.sh "safe-authd" "${SAFE_AUTHD_VERSION}"
+	./resources/package-deploy-artifacts.sh "safe-authd" "latest"
 	./resources/package-deploy-artifacts.sh "safe-cli" "${SAFE_CLI_VERSION}"
+	./resources/package-deploy-artifacts.sh "safe-cli" "latest"
 	./resources/package-deploy-artifacts.sh "safe-ffi" "${SAFE_FFI_VERSION}"
+	./resources/package-deploy-artifacts.sh "safe-ffi" "latest"
 	find deploy -name "safe-ffi-*.tar.gz" -exec rm '{}' \;


### PR DESCRIPTION
This commit was originally part of #592 but separating it out to unblock it

At the moment the release uploads all contain version numbers - this is
fine, but for CI purposes it would also be useful to have an additional file
with `latest` instead of a version number, so CI can point to it and not
be required to be manually updated after every release.

Example of where this will be used by SCL [here](https://github.com/maidsafe/safe-client-libs/pull/1224#issuecomment-655957414) and [here](https://github.com/maidsafe/safe-client-libs/pull/1229/files).

Note that a safe-ffi `latest` will be created, though it is not used anywhere at the moment. Thought it better to add anyway to be consistent.