### PR TITLE
chore(deps): update to use renamed sn_launch_tool dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3304,12 +3304,12 @@ dependencies = [
  "safe-api",
  "safe-cmd-test-utilities",
  "safe-nd",
- "safe-nlt",
  "self_update",
  "serde",
  "serde_json",
  "serde_yaml",
  "shrust",
+ "sn_launch_tool",
  "structopt 0.3.15",
  "tiny-keccak 1.5.0",
  "tokio 0.2.21",
@@ -3373,18 +3373,6 @@ dependencies = [
  "tiny-keccak 1.5.0",
  "unwrap",
  "xor_name",
-]
-
-[[package]]
-name = "safe-nlt"
-version = "0.0.1"
-source = "git+https://github.com/maidsafe/safe-network-launch-tool.git#ff4e258a0ef6a2e0fe5b16eba95537f06f00d6ce"
-dependencies = [
- "directories 2.0.2",
- "env_logger 0.7.1",
- "log 0.4.8",
- "regex 1.3.9",
- "structopt 0.3.15",
 ]
 
 [[package]]
@@ -3805,6 +3793,18 @@ dependencies = [
  "socket2",
  "wepoll-sys-stjepang",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "sn_launch_tool"
+version = "0.0.1"
+source = "git+https://github.com/maidsafe/sn_launch_tool.git#6953cc64e8659d93db54338ebf748b2f2a5e54e5"
+dependencies = [
+ "directories 2.0.2",
+ "env_logger 0.7.1",
+ "log 0.4.8",
+ "regex 1.3.9",
+ "structopt 0.3.15",
 ]
 
 [[package]]

--- a/safe-cli/Cargo.toml
+++ b/safe-cli/Cargo.toml
@@ -28,7 +28,7 @@ rand = "~0.7.3"
 relative-path = "~0.4.0"
 reqwest = "~0.9.22"
 rpassword = "4.0.5"
-safe-nlt = { git = "https://github.com/maidsafe/safe-network-launch-tool.git" }
+sn_launch_tool = { git = "https://github.com/maidsafe/sn_launch_tool.git" }
 serde = "1.0.91"
 serde_json = "1.0.39"
 serde_yaml = "~0.8.11"

--- a/safe-cli/operations/vault.rs
+++ b/safe-cli/operations/vault.rs
@@ -12,7 +12,7 @@ use directories::BaseDirs;
 use log::debug;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
-use safe_nlt::{join_with, run_with};
+use sn_launch_tool::{join_with, run_with};
 use std::{
     collections::HashMap,
     fs::create_dir_all,
@@ -101,8 +101,8 @@ pub fn vault_run(
     println!("Storing vaults' generated data at {}", arg_vaults_dir);
 
     // Let's create an args array to pass to the network launcher tool
-    let mut nlt_args = vec![
-        "safe-nlt",
+    let mut sn_launch_tool_args = vec![
+        "sn_launch_tool",
         "-v",
         "--vault-path",
         &arg_vault_path,
@@ -120,19 +120,22 @@ pub fn vault_run(
         let v = "y".repeat(verbosity as usize);
         println!("V: {}", v);
         verbosity_arg.push_str(&v);
-        nlt_args.push(&verbosity_arg);
+        sn_launch_tool_args.push(&verbosity_arg);
     }
 
     if let Some(ref launch_ip) = ip {
-        nlt_args.push("--ip");
-        nlt_args.push(launch_ip);
+        sn_launch_tool_args.push("--ip");
+        sn_launch_tool_args.push(launch_ip);
     };
 
-    debug!("Running network launch tool with args: {:?}", nlt_args);
+    debug!(
+        "Running network launch tool with args: {:?}",
+        sn_launch_tool_args
+    );
 
     // We can now call the tool with the args
     println!("Launching local SAFE network...");
-    run_with(Some(&nlt_args))?;
+    run_with(Some(&sn_launch_tool_args))?;
 
     let interval_duration = Duration::from_secs(interval_as_int * 15);
     thread::sleep(interval_duration);
@@ -209,8 +212,8 @@ pub fn vault_join(
     println!("Storing vaults' generated data at {}", arg_vaults_dir);
 
     // Let's create an args array to pass to the network launcher tool
-    let mut nlt_args = vec![
-        "safe-nlt-join",
+    let mut sn_launch_tool_args = vec![
+        "sn_launch_tool-join",
         "-v",
         "--vault-path",
         &arg_vault_path,
@@ -223,17 +226,20 @@ pub fn vault_join(
         let v = "y".repeat(verbosity as usize);
         println!("V: {}", v);
         verbosity_arg.push_str(&v);
-        nlt_args.push(&verbosity_arg);
+        sn_launch_tool_args.push(&verbosity_arg);
     }
 
-    nlt_args.push("--hard-coded-contacts");
-    nlt_args.push(contacts);
+    sn_launch_tool_args.push("--hard-coded-contacts");
+    sn_launch_tool_args.push(contacts);
 
-    debug!("Running network launch tool with args: {:?}", nlt_args);
+    debug!(
+        "Running network launch tool with args: {:?}",
+        sn_launch_tool_args
+    );
 
     // We can now call the tool with the args
     println!("Starting a vault to join a SAFE network...");
-    join_with(Some(&nlt_args))?;
+    join_with(Some(&sn_launch_tool_args))?;
     Ok(())
 }
 


### PR DESCRIPTION
launch tool was updated today [here](https://github.com/maidsafe/sn_launch_tool/pull/19/commits/3d826d4f8a3c7a0d19d0aa0a1463f688c622159b).
This PR updates all references to it (both to `safe-nlt` and `safe-network-launch-tool`) to match the new name